### PR TITLE
feat:state and sync observability hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,192 +1,255 @@
-# peam
+# Peam
 
-A minimal, high‑performance Lean Consensus client focused on clean SSZ, fast hashing, and practical networking.
+Peam is a minimal, performance-first Lean consensus client written in Rust.
 
-## Performance philosophy
-Performance is a feature.
+The project is built around a small core, fast SSZ and hashing paths, lean storage, and practical multi-client interoperability. The goal is not to be feature-heavy; the goal is to keep the critical path cheap, observable, and easy to reason about.
 
-Fast software does not just feel better to use; it changes how developers use it. Short feedback loops make tools more interactive, more trustworthy, and more likely to be used as a first pass instead of a last resort.
+## Status
 
-That means performance cannot be treated as a final cleanup pass. The biggest gains usually come from architecture, data flow, data structures, and serialization choices made early. Hot-spot tuning matters, but it cannot recover a design that bakes in avoidable overhead.
+- Alpha software
+- Suitable for experimentation, devnets, and benchmarking
+- Not intended for production mainnet use yet
 
-Peam therefore treats performance as a first-class design constraint:
-- optimize the architecture, not just the profiler output
-- prefer fast foundations over compensating layers
-- pay local complexity where it buys global simplicity
-- keep the critical path direct, observable, and cheap
+## What Peam Optimizes For
 
-A fast core reduces the need for elaborate caching, excessive bookkeeping, and coordination layers. That keeps the system simpler, easier to reason about, and easier to evolve.
+- Small, auditable codebase
+- Low-memory operation
+- Fast serialization and merkleization paths
+- Straightforward networking and sync behavior
+- Clean operational surface for mixed-client devnets
 
-## Project status
-- **Alpha**: APIs, storage layout, and behavior may change between releases.
-- The codebase is suitable for experimentation and benchmarking, not production mainnet use.
+## Prerequisites
 
-## Ops quick start
-
-### Prerequisites
 - Rust toolchain (`cargo`, `rustc`)
 - Git
-- Docker (optional, for images)
+- Docker (optional)
 
-### Build & test
+## Build
+
 ```bash
 cargo build
 cargo test
 ```
 
-### Run a single node
-Peam expects a small text config file (key=value). At minimum you need `genesis_time`.
+To build the binary only:
 
-Create a config file (example `node.conf`):
 ```bash
-cat > node.conf <<'EOF'
+cargo build --release -p peam --bin peam
+```
+
+## Quick Start
+
+Peam runs from a small `key=value` config file.
+
+Example `node.conf`:
+
+```text
 genesis_time=42
-# Optional network settings
-# listen_addr=/ip4/0.0.0.0/udp/9000/quic-v1
-# bootnodes=/ip4/127.0.0.1/udp/9001/quic-v1/p2p/12D3KooW...
-# validator_count=4
-# local_validator_index=0
-# http_api=true
-# metrics=true
-EOF
+http_api=true
+http_address=127.0.0.1
+http_port=5052
+metrics=true
+metrics_address=127.0.0.1
+metrics_port=8080
+listen_addr=/ip4/0.0.0.0/udp/9000/quic-v1
 ```
 
 Run the node:
+
 ```bash
 cargo run --release -- --run --config node.conf --data-dir /tmp/peam_data
 ```
 
-Run the node with checkpoint sync:
+Print the genesis root only:
+
+```bash
+cargo run --release -- --config node.conf
+```
+
+## Runtime Overrides
+
+Peam supports direct CLI overrides for the main devnet and quickstart paths.
+
+Example:
+
+```bash
+cargo run --release -- --run --config node.conf --data-dir /tmp/peam_data \
+  --listen /ip4/0.0.0.0/udp/9001/quic-v1 \
+  --bootnode /ip4/127.0.0.1/udp/9000/quic-v1/p2p/<peer-id> \
+  --metrics-port 8081 \
+  --http-port 5053 \
+  --node-id peam_0 \
+  --validator-keys /path/to/hash-sig-keys \
+  --is-aggregator
+```
+
+Checkpoint sync:
+
 ```bash
 cargo run --release -- --run --config node.conf --data-dir /tmp/peam_data \
   --checkpoint-sync-url http://localhost:5052
 ```
 
-Run with direct runtime overrides:
+leanSpec-style aliases supported by the CLI:
+
+- `--genesis`
+- `--custom_genesis`
+- `--network`
+- `--bootnodes`
+- `--validators`
+- `--validator-registry-path`
+- `--node-key`
+- `--metrics-port`
+- `--api-port`
+- `--http-port`
+- `--aggregator`
+
+For the full CLI surface:
+
 ```bash
-cargo run --release -- --run --config node.conf --data-dir /tmp/peam_data \
-  --listen /ip4/0.0.0.0/udp/9001/quic-v1 \
-  --bootnode /ip4/127.0.0.1/udp/9000/quic-v1/p2p/<peer-id> \
-  --api-port 5052 \
-  --is-aggregator
+cargo run --release -- -- --help
 ```
 
-To print the genesis root only (no node):
-```bash
-cargo run --release -- --config node.conf
-```
+## Config
 
-CLI flags are still small, but now include the main leanSpec-style runtime overrides:
-`--config`, `--data-dir`, `--run`, `--genesis-time`, `--checkpoint-sync-url`,
-`--listen`, `--bootnode`, `--api-port`, and `--is-aggregator`.
-Most other operational settings still live in the config file.
+Most operational settings can be supplied in the config file.
 
-### Run a multi-client devnet
-```bash
-./scripts/run_devnet2_3clients.sh
-```
+Common keys:
 
-### Ops notes
-- Data lives under `--data-dir` (defaults to `data_dir/store` when `storage_dir` is unset).
-- Logs are written by the devnet scripts into `.tmp/<run>/logs/`.
-- Metrics (if enabled) bind to `metrics_address:metrics_port` in the node config.
-- HTTP API endpoints are served when `http_api=true` (defaults to true).
-  - `/lean/v0/health`
-  - `/lean/v0/states/finalized`
-  - `/lean/v0/checkpoints/justified`
-  - `/lean/v0/fork_choice`
-  - `/metrics` (only when `metrics=true`)
-- Clean old devnet runs to reclaim disk:
-```bash
-rm -rf .tmp/devnet*
-```
-
-### Config keys (common)
-```text
-genesis_time=<u64>                 # required
-http_api=true|false                # default true
-metrics=true|false                 # default false
-metrics_address=127.0.0.1
-metrics_port=8080
-listen_addr=/ip4/0.0.0.0/udp/9000/quic-v1
-bootnodes=/ip4/.../p2p/...
-trusted_peers=/ip4/.../p2p/...
-validator_count=4
-local_validator_index=0
-checkpoint_sync_url=http://host:port
-```
-
-### Config keys (full)
 ```text
 genesis_time=<u64>
 http_api=true|false
+http_address=127.0.0.1
+http_port=5052
 metrics=true|false
 metrics_address=127.0.0.1
 metrics_port=8080
-metrics_node_name=peam_0
-metrics_client_name=peam
 listen_addr=/ip4/0.0.0.0/udp/9000/quic-v1
 node_key_path=/path/to/node.key
 bootnodes=/ip4/.../p2p/...
+bootnodes_file=/path/to/nodes.yaml
 trusted_peers=/ip4/.../p2p/...
-allowed_topics=/leanconsensus/devnet0/block/ssz_snappy,...
-topic_scores=/leanconsensus/devnet0/block/ssz_snappy:2,...
-topic_validators=/leanconsensus/devnet0/block/ssz_snappy=block,...
-max_gossip_bytes=2000000
-max_reqresp_bytes=4000000
-discovery_interval_secs=5
-score_decay_interval_secs=30
-score_decay_amount=1
-ban_threshold=-100
-is_aggregator=true|false
-attestation_committee_count=1
 validator_count=4
 local_validator_index=0
-storage_dir=store
-validator_config_path=validator-config.yaml
+attestation_committee_count=1
+is_aggregator=true|false
+validator_config_path=/path/to/validator-config.yaml
 checkpoint_sync_url=http://host:port
+storage_dir=store
 ```
 
-### Publish a devnet tag
-Push a tag (or dispatch the workflow with tags) to publish new images:
+A few notes:
+
+- `bootnodes_file` accepts a `nodes.yaml` / ENR file and is the cleanest path for quickstart-style deployments.
+- If `http_port` is omitted, it falls back to `metrics_port`.
+- If `http_address` is omitted, it falls back to `metrics_address`.
+- Setting `--metrics-port 0` disables metrics.
+- Setting `--api-port 0` disables the HTTP API listener.
+
+## HTTP API And Metrics
+
+Peam exposes:
+
+- `GET /v0/health`
+- `GET /lean/v0/health`
+- `GET /v0/states/finalized`
+- `GET /lean/v0/states/finalized`
+- `GET /v0/checkpoints/justified`
+- `GET /lean/v0/checkpoints/justified`
+- `GET /v0/fork_choice`
+- `GET /lean/v0/fork_choice`
+- `GET /metrics`
+
+By default:
+
+- HTTP API is enabled
+- Metrics are disabled unless `metrics=true`
+
+Example:
+
 ```bash
-git tag devnet3
-git push origin devnet3
+curl http://127.0.0.1:5052/v0/health
+curl http://127.0.0.1:8080/metrics | head
 ```
-Or use workflow dispatch with `tags=devnet3,devnet3-2026-03-19`.
 
 ## Docker
-Build from the Peam repo root.
+
+Build locally:
 
 ```bash
 docker build -t peam:local .
 ```
 
 Published images:
+
 - `ghcr.io/malik672/peam:latest`
 - `ghcr.io/malik672/peam:sha-<commit>`
-- `ghcr.io/malik672/peam:devnet3`
-- `ghcr.io/malik672/peam:devnet3-2026-03-19`
-- `ghcr.io/malik672/peam:<tag>` for pushed release/devnet tags
+- `ghcr.io/malik672/peam:<tag>`
 
-The GitHub Actions workflow at [`.github/workflows/docker_publish.yml`](./.github/workflows/docker_publish.yml)
-publishes multi-arch images to GHCR on `master`, on pushed tags, and on manual dispatch.
-
-For a local multi-arch build:
+Run with Docker:
 
 ```bash
-docker buildx build --platform linux/amd64,linux/arm64 -t peam:local .
+docker run --rm \
+  -v "$PWD/node.conf:/config/node.conf:ro" \
+  -v /tmp/peam_data:/data \
+  ghcr.io/malik672/peam:latest \
+  --run --config /config/node.conf --data-dir /data
 ```
 
-## Devnet status
-- Currently devnet 3
+The Docker publish workflow is:
+
+- `.github/workflows/docker_publish.yml`
+
+## Devnet Usage
+
+Run the mixed-client devnet script from the Peam repo:
+
+```bash
+./scripts/run_devnet2_3clients.sh
+```
+
+Logs are written under:
+
+```text
+.tmp/<run>/logs/
+```
+
+Clean old runs:
+
+```bash
+rm -rf .tmp/devnet*
+```
+
+## Development Notes
+
+- Peam uses a disk-backed store for long-lived chain data.
+- Fork choice is in memory and optimized for the live working set.
+- Metrics and logging are intended to be useful in mixed-client debugging, not only local happy-path runs.
 
 ## Contributing
-PRs welcome. Please run `cargo test` before opening a PR.
-Release notes are tracked in `CHANGELOG.md`.
+
+PRs are welcome.
+
+Before opening one, please run:
+
+```bash
+cargo test
+```
+
+If you are changing sync, state transition, or fork choice behavior, it is worth running at least one mixed-client devnet before pushing.
 
 ## License
-Dual-licensed under MIT or Apache-2.0. See `LICENSE` and `LICENSE-APACHE`.
+
+Dual-licensed under:
+
+- MIT
+- Apache-2.0
+
+See:
+
+- `LICENSE`
+- `LICENSE-APACHE`
 
 ## Acknowledgements
-- Some networking test structure and PQ verification flow were adapted from the Ream client.
+
+- Some networking test structure and PQ verification flow were adapted from Ream.

--- a/src/bin/debug_state_root.rs
+++ b/src/bin/debug_state_root.rs
@@ -34,7 +34,10 @@ fn parse_bytes32(hex: &str) -> Result<Bytes32, String> {
     Ok(Bytes32::from(out))
 }
 
-fn load_signed_block(store: &FileStore, root: &Bytes32) -> Result<SignedBlockWithAttestation, String> {
+fn load_signed_block(
+    store: &FileStore,
+    root: &Bytes32,
+) -> Result<SignedBlockWithAttestation, String> {
     store
         .get_signed_block(root)
         .ok_or_else(|| "signed block not found".to_string())
@@ -53,12 +56,12 @@ fn parse_slot(arg: &str) -> Option<u64> {
 
 fn main() -> Result<(), String> {
     let mut args = env::args().skip(1);
-    let store_dir = args
-        .next()
-        .ok_or_else(|| "usage: debug_state_root <store_dir> <block_root_hex|slot:NN>".to_string())?;
-    let selector = args
-        .next()
-        .ok_or_else(|| "usage: debug_state_root <store_dir> <block_root_hex|slot:NN>".to_string())?;
+    let store_dir = args.next().ok_or_else(|| {
+        "usage: debug_state_root <store_dir> <block_root_hex|slot:NN>".to_string()
+    })?;
+    let selector = args.next().ok_or_else(|| {
+        "usage: debug_state_root <store_dir> <block_root_hex|slot:NN>".to_string()
+    })?;
 
     let store = FileStore::open(PathBuf::from(store_dir))?;
     let block_root = if let Some(slot) = parse_slot(&selector) {
@@ -93,10 +96,7 @@ fn main() -> Result<(), String> {
         "block_state_root=0x{}",
         to_hex(&block.state_root.as_array())
     );
-    println!(
-        "parent_root=0x{}",
-        to_hex(&parent_root.as_array())
-    );
+    println!("parent_root=0x{}", to_hex(&parent_root.as_array()));
     println!(
         "parent_state_root=0x{}",
         to_hex(&parent_state_root.as_array())

--- a/src/checkpoint_sync.rs
+++ b/src/checkpoint_sync.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use crate::containers::attestation::{Attestation, AttestationData, VALIDATOR_REGISTRY_LIMIT};
 use crate::containers::block::{
-    AttestationSignatures, Attestations, Block, BlockBody, BlockSignatures,
-    BlockWithAttestation, SignedBlockWithAttestation,
+    AttestationSignatures, Attestations, Block, BlockBody, BlockSignatures, BlockWithAttestation,
+    SignedBlockWithAttestation,
 };
 use crate::containers::checkpoint::Checkpoint;
 use crate::containers::state::State;

--- a/src/containers/state.rs
+++ b/src/containers/state.rs
@@ -20,8 +20,8 @@
 
 use rapidhash::RapidHashMap;
 
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 use tracing::{info, warn};
 
@@ -249,7 +249,7 @@ impl State {
             return Err("target slot must be in the future".to_string());
         }
 
-        self.slot = Slot(Uint64(target_slot.0 .0));
+        self.slot = Slot(Uint64(target_slot.0.0));
 
         Ok(())
     }
@@ -306,8 +306,8 @@ impl State {
             self.latest_finalized.root = block.parent_root;
         }
 
-        let block_slot = block.slot.0 .0;
-        let latest_slot = self.latest_block_header.slot.0 .0;
+        let block_slot = block.slot.0.0;
+        let latest_slot = self.latest_block_header.slot.0.0;
         let num_empty_slots = block_slot - latest_slot - 1;
 
         // Record the parent root for the previous slot.
@@ -329,7 +329,7 @@ impl State {
         // Extend justified_slots to cover all slots up to (block.slot - 1).
         // matches across clients, even before attestation processing grows it.
         let last_materialized = block_slot.saturating_sub(1);
-        let fin_slot = self.latest_finalized.slot.0 .0;
+        let fin_slot = self.latest_finalized.slot.0.0;
         if last_materialized > fin_slot {
             let required_len = (last_materialized - fin_slot) as usize;
             if required_len > self.justified_slots.len() {
@@ -387,16 +387,16 @@ impl State {
     ) -> Result<(), String> {
         let total_start = Instant::now();
         let old_finalized = self.latest_finalized;
-        let pre_slot = self.slot.0 .0;
-        let pre_header_slot = self.latest_block_header.slot.0 .0;
+        let pre_slot = self.slot.0.0;
+        let pre_header_slot = self.latest_block_header.slot.0.0;
         let pre_header_root = Bytes32::from(self.latest_block_header.hash_tree_root());
         let pre_justified = self.latest_justified;
         let pre_finalized = self.latest_finalized;
 
         let slots_start = Instant::now();
-        let slots_before = self.slot.0 .0;
+        let slots_before = self.slot.0.0;
         self.process_slots(block.slot)?;
-        let slots_after = self.slot.0 .0;
+        let slots_after = self.slot.0.0;
         let capture_trace_roots = state_root_trace_enabled();
         let post_slots_root = if capture_trace_roots {
             Some(Bytes32::from(self.hash_tree_root()))
@@ -563,7 +563,7 @@ impl State {
                 }
                 continue;
             }
-            let source_slot_idx = att.data.source.slot.0 .0 as usize;
+            let source_slot_idx = att.data.source.slot.0.0 as usize;
             let source_matches = self
                 .historical_block_hashes
                 .data
@@ -583,7 +583,7 @@ impl State {
                 }
                 continue;
             }
-            let target_slot_idx = att.data.target.slot.0 .0 as usize;
+            let target_slot_idx = att.data.target.slot.0.0 as usize;
             let target_matches = self
                 .historical_block_hashes
                 .data
@@ -724,7 +724,7 @@ impl State {
                     slot: att.data.source.slot,
                 };
                 // Invariant: source.slot > old_finalized, so delta is strictly positive.
-                let delta = (self.latest_finalized.slot.0 .0 - old_finalized.0 .0) as usize;
+                let delta = (self.latest_finalized.slot.0.0 - old_finalized.0.0) as usize;
                 shift_justified_window(&mut self.justified_slots, delta);
                 finalized_slot = self.latest_finalized.slot;
                 let mut missing_root_to_slot = false;
@@ -745,12 +745,12 @@ impl State {
         }
         if trace_attestations && total_attestations > 0 {
             tracing::info!(
-                state_slot = self.slot.0 .0,
+                state_slot = self.slot.0.0,
                 attestations_total = total_attestations,
-                pre_justified_slot = pre_justified_slot.0 .0,
-                post_justified_slot = self.latest_justified.slot.0 .0,
-                pre_finalized_slot = pre_finalized_slot.0 .0,
-                post_finalized_slot = self.latest_finalized.slot.0 .0,
+                pre_justified_slot = pre_justified_slot.0.0,
+                post_justified_slot = self.latest_justified.slot.0.0,
+                pre_finalized_slot = pre_finalized_slot.0.0,
+                post_finalized_slot = self.latest_finalized.slot.0.0,
                 eligible_votes = stats.eligible_votes,
                 justified_updates = stats.justified_updates,
                 finalized_updates = stats.finalized_updates,
@@ -973,21 +973,21 @@ impl SignatureVerifier for PqSignatureVerifier {
                 &public_keys,
                 &message,
                 proof.proof_data.as_slice(),
-                att.data.slot.0 .0 as u32,
+                att.data.slot.0.0 as u32,
             ) {
                 return Err(err);
             }
         }
 
         let proposer_attestation = &signed.message.proposer_attestation;
-        let proposer_idx = block.proposer_index.0 .0 as usize;
+        let proposer_idx = block.proposer_index.0.0 as usize;
         let proposer = validators
             .get(proposer_idx)
             .ok_or_else(|| "proposer index out of range".to_string())?;
         let proposer_message = proposer_attestation.data.hash_tree_root();
         pq::verify_signature(
             &proposer.pubkey,
-            proposer_attestation.data.slot.0 .0 as u32,
+            proposer_attestation.data.slot.0.0 as u32,
             &proposer_message,
             &signed.signature.proposer_signature,
         )?;
@@ -1361,7 +1361,7 @@ fn is_slot_justified(justified: &JustifiedSlots, finalized: Slot, slot: Slot) ->
     if slot <= finalized {
         return true;
     }
-    let idx = (slot.0 .0 - finalized.0 .0 - 1) as usize;
+    let idx = (slot.0.0 - finalized.0.0 - 1) as usize;
     if idx >= justified.len() {
         return false;
     }
@@ -1387,7 +1387,7 @@ fn set_justified_slot(
     slot: Slot,
 ) -> Result<(), String> {
     // Caller invariant (process_attestations): slot is strictly after finalized.
-    let idx = (slot.0 .0 - finalized.0 .0 - 1) as usize;
+    let idx = (slot.0.0 - finalized.0.0 - 1) as usize;
     if idx >= HISTORICAL_ROOTS_LIMIT {
         return Err("justified slot exceeds limit".to_string());
     }
@@ -1410,7 +1410,7 @@ fn is_next_valid_justifiable_slot(source: Slot, target: Slot, finalized: Slot) -
     if target <= source {
         return false;
     }
-    for raw_slot in (source.0 .0 + 1)..target.0 .0 {
+    for raw_slot in (source.0.0 + 1)..target.0.0 {
         let slot = Slot(Uint64(raw_slot));
         if slot::is_justifiable_after(slot, finalized).unwrap_or(false) {
             return false;
@@ -1483,19 +1483,19 @@ impl SszEncode for State {
         let mut var_pos = 0usize;
 
         unsafe { write_bytes_at(&mut fixed, 0, &self.config.genesis_time.0.to_le_bytes()) };
-        unsafe { write_bytes_at(&mut fixed, 8, &self.slot.0 .0.to_le_bytes()) };
+        unsafe { write_bytes_at(&mut fixed, 8, &self.slot.0.0.to_le_bytes()) };
         unsafe {
             write_bytes_at(
                 &mut fixed,
                 16,
-                &self.latest_block_header.slot.0 .0.to_le_bytes(),
+                &self.latest_block_header.slot.0.0.to_le_bytes(),
             )
         };
         unsafe {
             write_bytes_at(
                 &mut fixed,
                 24,
-                &self.latest_block_header.proposer_index.0 .0.to_le_bytes(),
+                &self.latest_block_header.proposer_index.0.0.to_le_bytes(),
             )
         };
         unsafe {
@@ -1512,7 +1512,7 @@ impl SszEncode for State {
             write_bytes_at(
                 &mut fixed,
                 160,
-                &self.latest_justified.slot.0 .0.to_le_bytes(),
+                &self.latest_justified.slot.0.0.to_le_bytes(),
             )
         };
         unsafe { write_bytes_at(&mut fixed, 168, self.latest_finalized.root.as_ref()) };
@@ -1520,7 +1520,7 @@ impl SszEncode for State {
             write_bytes_at(
                 &mut fixed,
                 200,
-                &self.latest_finalized.slot.0 .0.to_le_bytes(),
+                &self.latest_finalized.slot.0.0.to_le_bytes(),
             )
         };
 

--- a/src/fork_choice.rs
+++ b/src/fork_choice.rs
@@ -833,7 +833,10 @@ impl ForkChoiceStore {
         if !self.node_indices.contains_key(&self.latest_justified.root) {
             self.latest_justified = self.latest_finalized;
         }
-        if !self.node_indices.contains_key(&self.previous_justified.root) {
+        if !self
+            .node_indices
+            .contains_key(&self.previous_justified.root)
+        {
             self.previous_justified = self.latest_justified;
         }
         if !self.node_indices.contains_key(&self.safe_target) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -279,6 +279,14 @@ pub struct MetricsRegistry {
     pub peer_connection_outbound: AtomicCounter,
     pub peer_disconnection_inbound: AtomicCounter,
     pub peer_disconnection_outbound: AtomicCounter,
+
+    // -- Sync/cache observability --
+    pub sync_inflight_roots: AtomicU64,
+    pub sync_request_active: AtomicU64,
+    pub sync_request_age_seconds: AtomicU64,
+    pub sync_pending_root_request: AtomicU64,
+    pub sync_pending_range_request: AtomicU64,
+    pub sync_active_peer_selected: AtomicU64,
 }
 
 impl MetricsRegistry {
@@ -332,6 +340,13 @@ impl MetricsRegistry {
             peer_connection_outbound: AtomicCounter::new(),
             peer_disconnection_inbound: AtomicCounter::new(),
             peer_disconnection_outbound: AtomicCounter::new(),
+
+            sync_inflight_roots: AtomicU64::new(0),
+            sync_request_active: AtomicU64::new(0),
+            sync_request_age_seconds: AtomicU64::new(0),
+            sync_pending_root_request: AtomicU64::new(0),
+            sync_pending_range_request: AtomicU64::new(0),
+            sync_active_peer_selected: AtomicU64::new(0),
         }
     }
 }
@@ -1045,6 +1060,36 @@ fn render_metrics(
     write_gauge_metric(&mut out, "lean_syncing", if syncing { 1 } else { 0 });
     write_gauge_metric(&mut out, "lean_sync_target_slot", sync_target_slot);
     write_gauge_metric(&mut out, "lean_sync_pending_depth", sync_pending_depth);
+    write_gauge_metric(
+        &mut out,
+        "lean_sync_inflight_roots",
+        registry.sync_inflight_roots.load(Ordering::Relaxed),
+    );
+    write_gauge_metric(
+        &mut out,
+        "lean_sync_request_active",
+        registry.sync_request_active.load(Ordering::Relaxed),
+    );
+    write_gauge_metric(
+        &mut out,
+        "lean_sync_request_age_seconds",
+        registry.sync_request_age_seconds.load(Ordering::Relaxed),
+    );
+    write_gauge_metric(
+        &mut out,
+        "lean_sync_pending_root_request",
+        registry.sync_pending_root_request.load(Ordering::Relaxed),
+    );
+    write_gauge_metric(
+        &mut out,
+        "lean_sync_pending_range_request",
+        registry.sync_pending_range_request.load(Ordering::Relaxed),
+    );
+    write_gauge_metric(
+        &mut out,
+        "lean_sync_active_peer_selected",
+        registry.sync_active_peer_selected.load(Ordering::Relaxed),
+    );
 
     // -- Storage --
     write_gauge_metric(
@@ -1305,6 +1350,8 @@ mod tests {
         assert!(r.start_time_seconds > 0);
         assert_eq!(r.pq_attestation_signatures_total.get(), 0);
         assert_eq!(r.fc_attestations_valid_total.get(), 0);
+        assert_eq!(r.sync_inflight_roots.load(Ordering::Relaxed), 0);
+        assert_eq!(r.sync_request_active.load(Ordering::Relaxed), 0);
         r.pq_attestation_signatures_total.inc();
         assert_eq!(r.pq_attestation_signatures_total.get(), 1);
     }

--- a/src/networking/gossipsub/context.rs
+++ b/src/networking/gossipsub/context.rs
@@ -12,9 +12,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use crate::containers::state::State;
-use crate::storage::{FileStore, Store};
 use crate::slot::{Slot, slot_index_from_unix_millis, unix_now_millis};
 use crate::ssz::HashTreeRoot;
+use crate::storage::{FileStore, Store};
 use crate::types::bytes::Bytes32;
 use crate::types::uint::Uint64;
 
@@ -231,10 +231,10 @@ impl RecentRootCache {
 
     #[inline]
     fn contains(&self, root: &Bytes32) -> bool {
-        self.entries
-            .iter()
-            .flatten()
-            .any(|entry| entry.root == *root && self.entries[(entry.slot as usize) % RECENT_ROOT_CACHE_LEN].is_some())
+        self.entries.iter().flatten().any(|entry| {
+            entry.root == *root
+                && self.entries[(entry.slot as usize) % RECENT_ROOT_CACHE_LEN].is_some()
+        })
     }
 }
 
@@ -244,7 +244,12 @@ impl StateGossipContext {
         let db_hit = self
             .store
             .as_ref()
-            .and_then(|store| store.read().ok().map(|guard| guard.get_block(root).is_some()))
+            .and_then(|store| {
+                store
+                    .read()
+                    .ok()
+                    .map(|guard| guard.get_block(root).is_some())
+            })
             .unwrap_or(false);
         tracing::trace!(
             queried_root = ?root,

--- a/src/networking/gossipsub/validate.rs
+++ b/src/networking/gossipsub/validate.rs
@@ -267,10 +267,10 @@ fn validate_subnet_attestation_with_context(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::containers::attestation::{Attestation, AggregatedSignatureProof};
+    use crate::containers::attestation::{AggregatedSignatureProof, Attestation};
     use crate::containers::block::{
-        AttestationSignatures, Attestations, Block, BlockBody, BlockSignatures, BlockWithAttestation,
-        SignedBlockWithAttestation,
+        AttestationSignatures, Attestations, Block, BlockBody, BlockSignatures,
+        BlockWithAttestation, SignedBlockWithAttestation,
     };
     use crate::containers::checkpoint::Checkpoint;
     use crate::containers::validator::ValidatorIndex;
@@ -321,7 +321,10 @@ mod tests {
         }
     }
 
-    fn block_with_unknown_attestation_roots(slot: u64, parent_root: Bytes32) -> SignedBlockWithAttestation {
+    fn block_with_unknown_attestation_roots(
+        slot: u64,
+        parent_root: Bytes32,
+    ) -> SignedBlockWithAttestation {
         let attestation = Attestation {
             aggregation_bits: BitList::new(vec![true]).expect("bitlist"),
             data: AttestationData {
@@ -348,16 +351,19 @@ mod tests {
                     parent_root,
                     state_root: Bytes32::zero(),
                     body: BlockBody {
-                        attestations: Attestations::new(vec![attestation.clone()]).expect("attestations"),
+                        attestations: Attestations::new(vec![attestation.clone()])
+                            .expect("attestations"),
                     },
                 },
                 proposer_attestation: attestation,
             },
             signature: BlockSignatures {
-                attestation_signatures: AttestationSignatures::new(vec![AggregatedSignatureProof {
-                    participants: BitList::new(vec![true]).expect("participants"),
-                    proof_data: ByteList::new(vec![0]).expect("proof bytes"),
-                }])
+                attestation_signatures: AttestationSignatures::new(vec![
+                    AggregatedSignatureProof {
+                        participants: BitList::new(vec![true]).expect("participants"),
+                        proof_data: ByteList::new(vec![0]).expect("proof bytes"),
+                    },
+                ])
                 .expect("attestation signatures"),
                 proposer_signature: Bytes3112::zero(),
             },

--- a/src/node/sync/manager.rs
+++ b/src/node/sync/manager.rs
@@ -31,6 +31,46 @@ use super::backfill::{
 use super::pending::PendingBackfill;
 
 #[inline]
+fn update_sync_observability(
+    metrics: &MetricsRegistry,
+    pending: &PendingBackfill,
+    in_flight_roots: &RapidHashSet<Bytes32>,
+) {
+    let request_active =
+        pending.pending_root.is_some() || pending.pending_range_start_slot.is_some();
+    let request_age_seconds = pending
+        .pending_since
+        .map(|since| since.elapsed().as_secs())
+        .unwrap_or(0);
+
+    metrics
+        .sync_inflight_roots
+        .store(in_flight_roots.len() as u64, Ordering::Relaxed);
+    metrics
+        .sync_request_active
+        .store(if request_active { 1 } else { 0 }, Ordering::Relaxed);
+    metrics
+        .sync_request_age_seconds
+        .store(request_age_seconds, Ordering::Relaxed);
+    metrics.sync_pending_root_request.store(
+        if pending.pending_root.is_some() { 1 } else { 0 },
+        Ordering::Relaxed,
+    );
+    metrics.sync_pending_range_request.store(
+        if pending.pending_range_start_slot.is_some() {
+            1
+        } else {
+            0
+        },
+        Ordering::Relaxed,
+    );
+    metrics.sync_active_peer_selected.store(
+        if pending.active_peer.is_some() { 1 } else { 0 },
+        Ordering::Relaxed,
+    );
+}
+
+#[inline]
 async fn request_root_from_peer(
     p2p_tx: &tokio::sync::mpsc::Sender<P2pCommand>,
     peer_id_str: &str,
@@ -199,7 +239,7 @@ pub(crate) fn spawn_status_sync_task(
     is_syncing: Arc<AtomicBool>,
     sync_target_slot: Arc<AtomicU64>,
     sync_pending_depth: Arc<AtomicU64>,
-    _metrics: Arc<MetricsRegistry>,
+    metrics: Arc<MetricsRegistry>,
 ) -> JoinHandle<()> {
     const SYNC_SLOT_LAG_THRESHOLD: u64 = 0;
     const MAX_BACKFILL_DEPTH: usize = 512;
@@ -219,10 +259,12 @@ pub(crate) fn spawn_status_sync_task(
         let mut pending = PendingBackfill::default();
         // Single-flight guard: while a root is in this set, never schedule it again.
         let mut in_flight_roots = RapidHashSet::<Bytes32>::default();
+        update_sync_observability(&metrics, &pending, &in_flight_roots);
 
         loop {
             tokio::select! {
                 _ = ticker.tick() => {
+                    update_sync_observability(&metrics, &pending, &in_flight_roots);
                     if pending.pending_root.is_some() || pending.pending_range_start_slot.is_some() {
                         if let Some(since) = pending.pending_since {
                             if since.elapsed() < SYNC_REQUEST_TIMEOUT {
@@ -244,6 +286,7 @@ pub(crate) fn spawn_status_sync_task(
                                 pending.fetched_chain_newest_to_oldest.clear();
                                 pending.active_peer = None;
                                 sync_pending_depth.store(0, Ordering::Relaxed);
+                                update_sync_observability(&metrics, &pending, &in_flight_roots);
                                 // Retry quickly against fresh peer statuses.
                                 last_status_probe = Instant::now()
                                     .checked_sub(STATUS_PROBE_INTERVAL)
@@ -265,6 +308,7 @@ pub(crate) fn spawn_status_sync_task(
                     }
                     // Wait for whichever peer returns an ahead status first.
                     pending.active_peer = None;
+                    update_sync_observability(&metrics, &pending, &in_flight_roots);
                 }
                 recv = events_rx.recv() => {
                     let event = match recv {
@@ -281,6 +325,7 @@ pub(crate) fn spawn_status_sync_task(
                     let NetworkEvent::ReqRespResponse { peer_id, protocol, payload } = event else {
                         continue;
                     };
+                    update_sync_observability(&metrics, &pending, &in_flight_roots);
                     let Some(kind) = LeanSupportedProtocol::parse_protocol_id(&protocol) else {
                         continue;
                     };
@@ -331,6 +376,7 @@ pub(crate) fn spawn_status_sync_task(
                                     in_flight_roots.clear();
                                     sync_target_slot.store(0, Ordering::Relaxed);
                                     sync_pending_depth.store(0, Ordering::Relaxed);
+                                    update_sync_observability(&metrics, &pending, &in_flight_roots);
                                 }
                                 continue;
                             }
@@ -351,6 +397,7 @@ pub(crate) fn spawn_status_sync_task(
                                 continue;
                             }
                             pending.set_target(peer_id.clone(), remote_status.head_root);
+                            update_sync_observability(&metrics, &pending, &in_flight_roots);
                             debug!(
                                 "sync requesting root={:?} from peer={}",
                                 remote_status.head_root,
@@ -371,6 +418,7 @@ pub(crate) fn spawn_status_sync_task(
                                 );
                                 in_flight_roots.remove(&remote_status.head_root);
                                 pending.reset();
+                                update_sync_observability(&metrics, &pending, &in_flight_roots);
                             }
                         }
                         LeanSupportedProtocol::BlocksByRangeV1 => {
@@ -410,6 +458,7 @@ pub(crate) fn spawn_status_sync_task(
                             );
                             pending.reset();
                             sync_pending_depth.store(0, Ordering::Relaxed);
+                            update_sync_observability(&metrics, &pending, &in_flight_roots);
                             let local_head = build_local_status(&state, &store).head_slot.0;
                             let target = sync_target_slot.load(Ordering::Relaxed);
                             if imported && local_head < target {
@@ -469,6 +518,7 @@ pub(crate) fn spawn_status_sync_task(
                             }
                             in_flight_roots.remove(&target_root);
                             pending.active_peer = Some(peer_id.clone());
+                            update_sync_observability(&metrics, &pending, &in_flight_roots);
 
                             let parent_root = signed.message.block.parent_root;
                             let signed_slot = signed.message.block.slot;
@@ -486,6 +536,7 @@ pub(crate) fn spawn_status_sync_task(
                                 is_syncing.store(false, Ordering::Relaxed);
                                 sync_target_slot.store(0, Ordering::Relaxed);
                                 sync_pending_depth.store(0, Ordering::Relaxed);
+                                update_sync_observability(&metrics, &pending, &in_flight_roots);
                                 continue;
                             }
 
@@ -564,6 +615,7 @@ pub(crate) fn spawn_status_sync_task(
                                 pending.reset();
                                 in_flight_roots.clear();
                                 sync_pending_depth.store(0, Ordering::Relaxed);
+                                update_sync_observability(&metrics, &pending, &in_flight_roots);
                                 if target != 0 && local_head < target {
                                     is_syncing.store(true, Ordering::Relaxed);
                                     last_status_probe = Instant::now()
@@ -578,6 +630,7 @@ pub(crate) fn spawn_status_sync_task(
 
                             pending.pending_root = Some(parent_root);
                             pending.pending_since = Some(Instant::now());
+                            update_sync_observability(&metrics, &pending, &in_flight_roots);
                             debug!(
                                 "sync chaining parent request child_root={:?} child_slot={} parent_root={:?} depth={} peer={}",
                                 signed_root,
@@ -617,6 +670,7 @@ pub(crate) fn spawn_status_sync_task(
                                 pending.active_peer = None;
                                 pending.fetched_chain_newest_to_oldest.clear();
                                 sync_pending_depth.store(0, Ordering::Relaxed);
+                                update_sync_observability(&metrics, &pending, &in_flight_roots);
                                 last_status_probe = Instant::now()
                                     .checked_sub(STATUS_PROBE_INTERVAL)
                                     .unwrap_or_else(Instant::now);

--- a/src/node/sync/pending.rs
+++ b/src/node/sync/pending.rs
@@ -31,5 +31,4 @@ impl PendingBackfill {
         self.pending_since = Some(Instant::now());
         self.fetched_chain_newest_to_oldest.clear();
     }
-
 }

--- a/src/storage/canonical_db.rs
+++ b/src/storage/canonical_db.rs
@@ -209,7 +209,15 @@ impl CanonicalDb {
     /// A missing key yields `None` for that position (normal for a fresh DB).
     pub(super) fn load_meta(
         &self,
-    ) -> Result<(Option<Bytes32>, Option<Bytes32>, Option<Bytes32>, Option<u64>), String> {
+    ) -> Result<
+        (
+            Option<Bytes32>,
+            Option<Bytes32>,
+            Option<Bytes32>,
+            Option<u64>,
+        ),
+        String,
+    > {
         let read_txn = self.db.begin_read().map_err(to_string)?;
         let table = read_txn.open_table(META_TABLE).map_err(to_string)?;
 
@@ -526,9 +534,7 @@ fn upsert_or_remove_meta_u64(
 ) -> Result<(), String> {
     if let Some(value) = value {
         let bytes = value.to_le_bytes();
-        table
-            .insert(key, bytes.as_ref())
-            .map_err(to_string)?;
+        table.insert(key, bytes.as_ref()).map_err(to_string)?;
     } else {
         let _ = table.remove(key).map_err(to_string)?;
     }

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -36,8 +36,8 @@
 //! `persist_signed_block_bundle` transaction.
 
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 use tracing::warn;
 
@@ -111,15 +111,15 @@ struct StateSnapshot {
 impl StateSnapshot {
     fn capture(state: &State) -> Self {
         Self {
-            slot: state.slot.0 .0,
+            slot: state.slot.0.0,
             state_root: Bytes32::from(state.hash_tree_root()),
-            header_slot: state.latest_block_header.slot.0 .0,
+            header_slot: state.latest_block_header.slot.0.0,
             header_root: Bytes32::from(state.latest_block_header.hash_tree_root()),
             header_parent_root: state.latest_block_header.parent_root,
             header_state_root: state.latest_block_header.state_root,
-            justified_slot: state.latest_justified.slot.0 .0,
+            justified_slot: state.latest_justified.slot.0.0,
             justified_root: state.latest_justified.root,
-            finalized_slot: state.latest_finalized.slot.0 .0,
+            finalized_slot: state.latest_finalized.slot.0.0,
             finalized_root: state.latest_finalized.root,
             historical_len: state.historical_block_hashes.data.len(),
             historical_tail: state.historical_block_hashes.data.last().copied(),
@@ -385,7 +385,7 @@ impl FileStore {
         if self.finalized_slot.is_none() {
             self.finalized_slot = self
                 .finalized
-                .and_then(|root| self.load_block_by_root(&root).map(|block| block.slot.0 .0));
+                .and_then(|root| self.load_block_by_root(&root).map(|block| block.slot.0.0));
         }
         self.recovery.loaded_states = self.state_by_slot.len();
         self.recovery.loaded_blocks = self.block_by_slot.len();
@@ -470,7 +470,7 @@ impl FileStore {
     ) -> Result<(), String> {
         static PERSIST_LOGS: OnceLock<AtomicUsize> = OnceLock::new();
         let block = signed.message.block.clone();
-        let slot = block.slot.0 .0;
+        let slot = block.slot.0.0;
         let state_root = block.state_root;
         let block_blob = encode_blob(BLOB_KIND_BLOCK, &block.encode_ssz());
         let signed_blob = encode_blob(BLOB_KIND_SIGNED_BLOCK, &signed.encode_ssz());
@@ -480,7 +480,7 @@ impl FileStore {
             self.head = Some(root);
             self.justified = Some(meta_justified.root);
             self.finalized = Some(meta_finalized.root);
-            self.finalized_slot = Some(meta_finalized.slot.0 .0);
+            self.finalized_slot = Some(meta_finalized.slot.0.0);
             self.set_meta_dirty();
         }
 
@@ -501,7 +501,7 @@ impl FileStore {
             );
         }
 
-        let fin_slot = meta_finalized.slot.0 .0;
+        let fin_slot = meta_finalized.slot.0.0;
         let block_canonical = self.index_block_slot(slot, root, state_root);
         self.index_state_slot(slot, state_root);
 
@@ -911,7 +911,7 @@ impl Store for FileStore {
 
     #[inline]
     fn put_state(&mut self, root: Bytes32, state: State) {
-        let slot = state.slot.0 .0;
+        let slot = state.slot.0.0;
         // Blob write must succeed before canonical indexes can reference this root.
         if self.persist_state(root, &state).is_err() {
             return;
@@ -930,7 +930,7 @@ impl Store for FileStore {
 
     #[inline]
     fn put_block(&mut self, root: Bytes32, block: Block) {
-        let slot = block.slot.0 .0;
+        let slot = block.slot.0.0;
         let state_root = block.state_root;
         // Blob write must succeed before canonical indexes can reference this root.
         if self.persist_block(root, &block).is_err() {
@@ -997,7 +997,7 @@ impl Store for FileStore {
             warn!("set_finalized called with unknown root; ignoring");
             return;
         };
-        let slot = block.slot.0 .0;
+        let slot = block.slot.0.0;
         if let Some(current) = self.finalized_slot {
             if slot < current {
                 warn!(
@@ -1019,7 +1019,7 @@ impl Store for FileStore {
     /// Sets finalized checkpoint root + slot explicitly, then flushes metadata.
     #[inline]
     fn set_finalized_checkpoint(&mut self, checkpoint: Checkpoint) {
-        let slot = checkpoint.slot.0 .0;
+        let slot = checkpoint.slot.0.0;
         if let Some(current) = self.finalized_slot {
             if slot < current {
                 warn!(

--- a/src/storage/prune.rs
+++ b/src/storage/prune.rs
@@ -42,9 +42,7 @@ impl FileStore {
         let mut report = PruneReport::default();
         info!(
             finalized_slot,
-            keep_recent_slots,
-            prune_before,
-            "storage prune started"
+            keep_recent_slots, prune_before, "storage prune started"
         );
 
         // Canonical state index prune.

--- a/tests/checkpoint_sync.rs
+++ b/tests/checkpoint_sync.rs
@@ -147,7 +147,10 @@ fn verify_checkpoint_state_rejects_header_root_mismatch() {
     state.latest_finalized.root = Bytes32::from([2u8; 32]);
 
     let err = verify_checkpoint_state(&state, &expected_genesis).unwrap_err();
-    assert!(err.contains("finalized root does not match header root"), "{err}");
+    assert!(
+        err.contains("finalized root does not match header root"),
+        "{err}"
+    );
 }
 
 #[test]

--- a/tests/fork_choice_store.rs
+++ b/tests/fork_choice_store.rs
@@ -421,7 +421,9 @@ fn finalized_advance_prunes_old_fork_choice_history() {
 
     let (block_2a, state_2a, root_2a) = build_signed_block(&anchor_state, 2, false);
     let (block_2b, state_2b, root_2b) = build_signed_block(&anchor_state, 2, true);
-    store.on_block(block_2a, state_2a.clone()).expect("block 2a");
+    store
+        .on_block(block_2a, state_2a.clone())
+        .expect("block 2a");
     store.on_block(block_2b, state_2b).expect("block 2b");
 
     let (mut block_3, mut state_3, _root_3) = build_signed_block(&state_2a, 3, false);

--- a/tests/lean_spec_genesis.rs
+++ b/tests/lean_spec_genesis.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::uninit_vec)]
 
-use peam::containers::block::{Attestations, BlockBody};
 use peam::checkpoint_sync::build_anchor_block;
+use peam::containers::block::{Attestations, BlockBody};
 use peam::containers::state::{State, Validators};
 use peam::containers::validator::{Validator, ValidatorIndex};
 use peam::slot::Slot;


### PR DESCRIPTION
- make signed block processing transactional so failed state-root checks do not mutate live state
- add targeted mismatch investigation logging for live-import vs replay-from-parent state divergence
- prune finalized-old fork-choice history to keep long-run fork-choice state bounded
- add sync/cache observability metrics for in-flight roots, active requests, request age, and selected peer state
- refresh README and related docs/tests touched during this hardening pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with new Quick Start section, runtime overrides documentation, and expanded configuration guidance.
  * Added HTTP API/metrics endpoint documentation with example commands.
  * Included Docker usage examples.

* **New Features**
  * Added six new sync and cache observability metrics for monitoring purposes.
  * Introduced CLI aliases for configuration parameters.

* **Style**
  * Code formatting improvements across multiple files.
  * Refined sync manager observability tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->