### PR TITLE
feat: align empty-slot processing with lean spec

### DIFF
--- a/src/containers/state.rs
+++ b/src/containers/state.rs
@@ -249,7 +249,12 @@ impl State {
             return Err("target slot must be in the future".to_string());
         }
 
-        self.slot = Slot(Uint64(target_slot.0.0));
+        while self.slot < target_slot {
+            if self.latest_block_header.state_root == Bytes32::zero() {
+                self.latest_block_header.state_root = Bytes32::from(self.hash_tree_root());
+            }
+            self.slot = Slot(Uint64(self.slot.0.0 + 1));
+        }
 
         Ok(())
     }

--- a/tests/checkpoint_sync.rs
+++ b/tests/checkpoint_sync.rs
@@ -25,6 +25,7 @@ fn make_validators(n: usize) -> Validators {
 fn base_state(genesis_time: u64, validator_count: usize) -> State {
     let validators = make_validators(validator_count);
     let mut state = State::generate_genesis(Uint64(genesis_time), validators);
+    state.latest_block_header.state_root = Bytes32::zero();
     let header_root = Bytes32::from(state.latest_block_header.hash_tree_root());
     state.latest_finalized.root = header_root;
     state.latest_justified.root = header_root;
@@ -168,7 +169,8 @@ fn verify_checkpoint_state_rejects_state_root_mismatch() {
 
 #[test]
 fn build_anchor_block_uses_computed_state_root_when_header_is_zero() {
-    let state = base_state(10, 2);
+    let mut state = base_state(10, 2);
+    state.latest_block_header.state_root = Bytes32::zero();
     let anchor = build_anchor_block(&state);
     let expected_root = Bytes32::from(state.hash_tree_root());
     assert_eq!(anchor.state_root, expected_root);

--- a/tests/lean_spec_container_placeholders.rs
+++ b/tests/lean_spec_container_placeholders.rs
@@ -263,80 +263,61 @@ fn lean_spec_state_justified_slots() {
     ])
     .expect("validators");
     let mut state = State::generate_genesis(Uint64(0), validators);
+    let block_1 = build_block_for_slot(&state, 1, 1, vec![]);
+    state.process_slots(block_1.slot).expect("process slots for block 1");
+    state.process_block(&block_1).expect("process block 1");
+    state.latest_block_header.state_root = block_1.state_root;
+    let block_2_preview = build_block_for_slot(&state, 2, 2, vec![]);
 
-    state.process_slots(Slot(Uint64(1))).expect("process slots");
-    let parent_root_1 = Bytes32::from(state.latest_block_header.hash_tree_root());
-    let body = BlockBody {
-        attestations: Attestations::new(vec![]).expect("attestations"),
-    };
-    let header_1 = BlockHeader {
-        slot: Slot(Uint64(1)),
-        proposer_index: ValidatorIndex(Uint64(1)),
-        parent_root: parent_root_1,
-        state_root: Bytes32::zero(),
-        body_root: Bytes32::from(body.hash_tree_root()),
-    };
-    state
-        .process_block_header(header_1)
-        .expect("process header");
     let att_1 = Attestation {
-        aggregation_bits: BitList::new(vec![true, true, false]).expect("bits"),
-        data: AttestationData {
-            slot: Slot(Uint64(1)),
-            head: Checkpoint {
-                root: Bytes32::from(state.latest_block_header.hash_tree_root()),
-                slot: Slot(Uint64(1)),
-            },
-            target: Checkpoint {
-                root: Bytes32::from(state.latest_block_header.hash_tree_root()),
-                slot: Slot(Uint64(1)),
-            },
-            source: Checkpoint {
-                root: state.latest_justified.root,
-                slot: state.latest_justified.slot,
-            },
-        },
-    };
-    state
-        .process_attestations(&Attestations::new(vec![att_1]).expect("attestations"))
-        .expect("process attestations");
-    assert_eq!(state.latest_justified.slot, Slot(Uint64(1)));
-    assert_eq!(state.latest_finalized.slot, Slot(Uint64(0)));
-    assert_eq!(state.justified_slots.len(), 1);
-
-    state.process_slots(Slot(Uint64(2))).expect("process slots");
-    let parent_root_2 = Bytes32::from(state.latest_block_header.hash_tree_root());
-    let header_2 = BlockHeader {
-        slot: Slot(Uint64(2)),
-        proposer_index: ValidatorIndex(Uint64(2)),
-        parent_root: parent_root_2,
-        state_root: Bytes32::zero(),
-        body_root: Bytes32::from(body.hash_tree_root()),
-    };
-    state
-        .process_block_header(header_2)
-        .expect("process header");
-    let att_2 = Attestation {
         aggregation_bits: BitList::new(vec![true, true, false]).expect("bits"),
         data: AttestationData {
             slot: Slot(Uint64(2)),
             head: Checkpoint {
-                root: Bytes32::from(state.latest_block_header.hash_tree_root()),
-                slot: Slot(Uint64(2)),
+                root: block_2_preview.parent_root,
+                slot: Slot(Uint64(1)),
             },
             target: Checkpoint {
-                root: Bytes32::from(state.latest_block_header.hash_tree_root()),
-                slot: Slot(Uint64(2)),
+                root: block_2_preview.parent_root,
+                slot: Slot(Uint64(1)),
             },
             source: Checkpoint {
-                root: state.latest_justified.root,
-                slot: state.latest_justified.slot,
+                root: block_1.parent_root,
+                slot: Slot(Uint64(0)),
             },
         },
     };
-    state
-        .process_attestations(&Attestations::new(vec![att_2]).expect("attestations"))
-        .expect("process attestations");
+    let block_2 = build_block_for_slot(&state, 2, 2, vec![att_1]);
+    state.process_slots(block_2.slot).expect("process slots for block 2");
+    state.process_block(&block_2).expect("process block 2");
+    state.latest_block_header.state_root = block_2.state_root;
+    assert_eq!(state.latest_justified.slot, Slot(Uint64(1)));
+    assert_eq!(state.latest_finalized.slot, Slot(Uint64(0)));
+    assert_eq!(state.justified_slots.len(), 1);
+    let block_3_preview = build_block_for_slot(&state, 3, 0, vec![]);
+
+    let att_2 = Attestation {
+        aggregation_bits: BitList::new(vec![true, true, false]).expect("bits"),
+        data: AttestationData {
+            slot: Slot(Uint64(3)),
+            head: Checkpoint {
+                root: block_3_preview.parent_root,
+                slot: Slot(Uint64(2)),
+            },
+            target: Checkpoint {
+                root: block_3_preview.parent_root,
+                slot: Slot(Uint64(2)),
+            },
+            source: Checkpoint {
+                root: block_2.parent_root,
+                slot: Slot(Uint64(1)),
+            },
+        },
+    };
+    let block_3 = build_block_for_slot(&state, 3, 0, vec![att_2]);
+    state.process_slots(block_3.slot).expect("process slots for block 3");
+    state.process_block(&block_3).expect("process block 3");
+    state.latest_block_header.state_root = block_3.state_root;
 
     // Finalization advanced to slot 1, so justified window rebased by 1 slot.
     assert_eq!(state.latest_finalized.slot, Slot(Uint64(1)));

--- a/tests/state_logic.rs
+++ b/tests/state_logic.rs
@@ -31,6 +31,20 @@ fn process_slots_advances_state_and_sets_root() {
 }
 
 #[test]
+fn process_slots_caches_zeroed_latest_header_state_root() {
+    let validators: Validators = SszList::new(vec![]).expect("validators");
+    let mut state = State::generate_genesis(Uint64(0), validators);
+    state.latest_block_header.state_root = Bytes32::zero();
+
+    let expected_root = Bytes32::from(state.hash_tree_root());
+
+    state.process_slots(Slot(Uint64(1))).expect("process slots");
+
+    assert_eq!(state.slot, Slot(Uint64(1)));
+    assert_eq!(state.latest_block_header.state_root, expected_root);
+}
+
+#[test]
 fn process_block_header_updates_latest_header() {
     let v = Validator {
         pubkey: Bytes52::from([0x01u8; 52]),
@@ -763,6 +777,7 @@ fn attestations_accumulate_votes_across_calls_for_justification_and_finalization
     state
         .process_block_header(header_1)
         .expect("process header slot 1");
+    state.latest_block_header.state_root = Bytes32::from(state.hash_tree_root());
     state.latest_justified.root = header_1.parent_root;
     state.latest_finalized.root = header_1.parent_root;
 
@@ -814,6 +829,7 @@ fn attestations_accumulate_votes_across_calls_for_justification_and_finalization
     state
         .process_block_header(header_2)
         .expect("process header slot 2");
+    state.latest_block_header.state_root = Bytes32::from(state.hash_tree_root());
 
     let target_2 = Checkpoint {
         root: Bytes32::from(state.latest_block_header.hash_tree_root()),


### PR DESCRIPTION
- advance slots one-by-one so empty-slot processing matches lean spec expectations
- cache the latest header state root when slot processing starts from a zeroed header root
- add regression coverage for checkpoint sync and state logic around the updated slot-processing path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slot advancement now increments through slots and caches block header state roots as they are computed, ensuring headers initialized with zero roots are populated during progression.

* **Tests**
  * Added coverage validating state-root caching during slot advancement.
  * Updated and refactored tests to exercise full block-processing flows and to align setups with zeroed header state-root behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->