### PR TITLE
Feat: Store state blobs by block root

### DIFF
--- a/src/storage/canonical_db.rs
+++ b/src/storage/canonical_db.rs
@@ -173,6 +173,18 @@ impl CanonicalDb {
         Ok(out)
     }
 
+    /// Loads every state-blob key currently present in canonical storage.
+    pub(super) fn load_state_blob_roots(&self) -> Result<RapidHashSet<Bytes32>, String> {
+        let read_txn = self.db.begin_read().map_err(to_string)?;
+        let table = read_txn.open_table(STATE_BLOB_TABLE).map_err(to_string)?;
+        let mut out = RapidHashSet::default();
+        for row in table.iter().map_err(to_string)? {
+            let (root, _) = row.map_err(to_string)?;
+            out.insert(bytes_to_root(root.value())?);
+        }
+        Ok(out)
+    }
+
     /// Generic slot-index loader. Opens a read txn, iterates every row in the
     /// B-tree, and builds a `slot → Bytes32` hashmap. Cost is proportional
     /// to the number of canonical rows (one B-tree scan).

--- a/src/storage/canonical_db.rs
+++ b/src/storage/canonical_db.rs
@@ -12,14 +12,16 @@
 //! │ canonical_state_slot       │ u64 (slot)   │ [u8] (Bytes32 root)       │
 //! │ canonical_block_slot       │ u64 (slot)   │ [u8] (Bytes32 root)       │
 //! │ canonical_meta             │ &str (key)   │ [u8] (Bytes32 root)       │
+//! │ canonical_state_root_index │ [u8]         │ [u8] (block root)         │
 //! │ canonical_state_blob       │ [u8] (root)  │ [u8] (LEANSTRG envelope)  │
 //! │ canonical_block_blob       │ [u8] (root)  │ [u8] (LEANSTRG envelope)  │
 //! │ canonical_signed_block_blob│ [u8] (root)  │ [u8] (LEANSTRG envelope)  │
 //! └────────────────────────────┴──────────────┴───────────────────────────┘
 //! ```
 //!
-//! Slot tables map `slot → root` (canonical index). Blob tables map
-//! `root → envelope` (the actual serialized data). Meta stores three
+//! Slot tables map `slot → root` (canonical index). `canonical_state_root_index`
+//! maps `state_root → block_root`. Blob tables map `root → envelope` (the
+//! actual serialized data). Meta stores three
 //! string-keyed roots: `"head"`, `"finalized"`, `"justified"`, plus
 //! an optional `"finalized_slot"` u64 for checkpoint sync metadata.
 //!
@@ -47,7 +49,10 @@ const BLOCK_SLOT_TABLE: TableDefinition<'static, u64, &'static [u8]> =
 /// plus `"finalized_slot" → u64` (LE bytes).
 const META_TABLE: TableDefinition<'static, &'static str, &'static [u8]> =
     TableDefinition::new("canonical_meta");
-/// State blobs keyed by root: `Bytes32 state_root → LEANSTRG envelope`.
+/// State root lookup: `Bytes32 state_root → Bytes32 block_root`.
+const STATE_ROOT_INDEX_TABLE: TableDefinition<'static, &'static [u8], &'static [u8]> =
+    TableDefinition::new("canonical_state_root_index");
+/// State blobs keyed by block root: `Bytes32 block_root → LEANSTRG envelope`.
 const STATE_BLOB_TABLE: TableDefinition<'static, &'static [u8], &'static [u8]> =
     TableDefinition::new("canonical_state_blob");
 /// Block blobs keyed by root: `Bytes32 block_root → LEANSTRG envelope`.
@@ -110,12 +115,13 @@ impl CanonicalDb {
         read_txn.open_table(STATE_SLOT_TABLE).is_ok()
             && read_txn.open_table(BLOCK_SLOT_TABLE).is_ok()
             && read_txn.open_table(META_TABLE).is_ok()
+            && read_txn.open_table(STATE_ROOT_INDEX_TABLE).is_ok()
             && read_txn.open_table(STATE_BLOB_TABLE).is_ok()
             && read_txn.open_table(BLOCK_BLOB_TABLE).is_ok()
             && read_txn.open_table(SIGNED_BLOCK_BLOB_TABLE).is_ok()
     }
 
-    /// Creates all 6 tables if they don't already exist.
+    /// Creates all canonical tables if they don't already exist.
     ///
     /// redb's `open_table` inside a write txn is idempotent — it creates the
     /// table on first call and returns the existing handle on subsequent calls.
@@ -128,6 +134,9 @@ impl CanonicalDb {
             let _ = write_txn.open_table(STATE_SLOT_TABLE).map_err(to_string)?;
             let _ = write_txn.open_table(BLOCK_SLOT_TABLE).map_err(to_string)?;
             let _ = write_txn.open_table(META_TABLE).map_err(to_string)?;
+            let _ = write_txn
+                .open_table(STATE_ROOT_INDEX_TABLE)
+                .map_err(to_string)?;
             let _ = write_txn.open_table(STATE_BLOB_TABLE).map_err(to_string)?;
             let _ = write_txn.open_table(BLOCK_BLOB_TABLE).map_err(to_string)?;
             let _ = write_txn
@@ -147,6 +156,21 @@ impl CanonicalDb {
     /// Called once at startup by [`FileStore::load_from_disk`].
     pub(super) fn load_block_index(&self) -> Result<RapidHashMap<u64, Bytes32>, String> {
         self.load_slot_index(BLOCK_SLOT_TABLE)
+    }
+
+    /// Loads the full `state_root -> block_root` lookup table into memory.
+    pub(super) fn load_state_root_index(&self) -> Result<RapidHashMap<Bytes32, Bytes32>, String> {
+        let read_txn = self.db.begin_read().map_err(to_string)?;
+        let table = read_txn.open_table(STATE_ROOT_INDEX_TABLE).map_err(to_string)?;
+        let mut out = RapidHashMap::default();
+        for row in table.iter().map_err(to_string)? {
+            let (state_root, block_root) = row.map_err(to_string)?;
+            out.insert(
+                bytes_to_root(state_root.value())?,
+                bytes_to_root(block_root.value())?,
+            );
+        }
+        Ok(out)
     }
 
     /// Generic slot-index loader. Opens a read txn, iterates every row in the
@@ -314,9 +338,17 @@ impl CanonicalDb {
     ) -> Result<(), String> {
         let write_txn = self.db.begin_write().map_err(to_string)?;
         {
+            let mut state_root_index = write_txn
+                .open_table(STATE_ROOT_INDEX_TABLE)
+                .map_err(to_string)?;
+            state_root_index
+                .insert(state_root.as_array().as_slice(), block_root.as_array().as_slice())
+                .map_err(to_string)?;
+        }
+        {
             let mut state_blob_table = write_txn.open_table(STATE_BLOB_TABLE).map_err(to_string)?;
             state_blob_table
-                .insert(state_root.as_array().as_slice(), state_blob)
+                .insert(block_root.as_array().as_slice(), state_blob)
                 .map_err(to_string)?;
         }
         {
@@ -387,10 +419,32 @@ impl CanonicalDb {
         self.with_blob(SIGNED_BLOCK_BLOB_TABLE, root, f)
     }
 
-    /// Writes a state blob (already LEANSTRG-wrapped) keyed by state root.
+    /// Writes a state-root lookup row: `state_root -> block_root`.
+    pub(super) fn persist_state_root_mapping(
+        &self,
+        state_root: Bytes32,
+        block_root: Bytes32,
+    ) -> Result<(), String> {
+        let write_txn = self.db.begin_write().map_err(to_string)?;
+        {
+            let mut table = write_txn
+                .open_table(STATE_ROOT_INDEX_TABLE)
+                .map_err(to_string)?;
+            table
+                .insert(state_root.as_array().as_slice(), block_root.as_array().as_slice())
+                .map_err(to_string)?;
+        }
+        write_txn.commit().map_err(to_string)
+    }
+
+    /// Writes a state blob (already LEANSTRG-wrapped) keyed by block root.
     /// Used by [`FileStore::put_state`] for individual state persistence.
-    pub(super) fn persist_state_blob(&self, root: Bytes32, encoded: &[u8]) -> Result<(), String> {
-        self.persist_blob(STATE_BLOB_TABLE, root, encoded)
+    pub(super) fn persist_state_blob(
+        &self,
+        block_root: Bytes32,
+        encoded: &[u8],
+    ) -> Result<(), String> {
+        self.persist_blob(STATE_BLOB_TABLE, block_root, encoded)
     }
 
     /// Writes a block blob (already LEANSTRG-wrapped) keyed by block root.
@@ -401,18 +455,18 @@ impl CanonicalDb {
 
     /// Removes blob rows that are no longer referenced by canonical/pending roots.
     ///
-    /// `keep_state_roots` is used for state blobs and `keep_block_roots` for
+    /// `keep_state_block_roots` is used for state blobs and `keep_block_roots` for
     /// block + signed block blobs.
     pub(super) fn gc_unreferenced_blobs(
         &self,
-        keep_state_roots: &RapidHashSet<Bytes32>,
+        keep_state_block_roots: &RapidHashSet<Bytes32>,
         keep_block_roots: &RapidHashSet<Bytes32>,
     ) -> Result<BlobGcReport, String> {
         let write_txn = self.db.begin_write().map_err(to_string)?;
         let report = {
             let mut state_blob_table = write_txn.open_table(STATE_BLOB_TABLE).map_err(to_string)?;
-            let removed_state_blobs =
-                gc_blob_table(&mut state_blob_table, keep_state_roots).map_err(to_string)?;
+            let removed_state_blobs = gc_blob_table(&mut state_blob_table, keep_state_block_roots)
+                .map_err(to_string)?;
 
             let mut block_blob_table = write_txn.open_table(BLOCK_BLOB_TABLE).map_err(to_string)?;
             let removed_block_blobs =

--- a/src/storage/canonical_db.rs
+++ b/src/storage/canonical_db.rs
@@ -289,6 +289,7 @@ impl CanonicalDb {
         &self,
         state_index: &RapidHashMap<u64, Bytes32>,
         block_index: &RapidHashMap<u64, Bytes32>,
+        state_root_index: &RapidHashMap<Bytes32, Bytes32>,
         head: Option<Bytes32>,
         finalized: Option<Bytes32>,
         finalized_slot: Option<u64>,
@@ -310,6 +311,17 @@ impl CanonicalDb {
             for (slot, root) in block_index {
                 block_table
                     .insert(*slot, root.as_array().as_slice())
+                    .map_err(to_string)?;
+            }
+        }
+        {
+            let mut state_root_table = write_txn
+                .open_table(STATE_ROOT_INDEX_TABLE)
+                .map_err(to_string)?;
+            clear_bytes_table(&mut state_root_table)?;
+            for (state_root, block_root) in state_root_index {
+                state_root_table
+                    .insert(state_root.as_array().as_slice(), block_root.as_array().as_slice())
                     .map_err(to_string)?;
             }
         }
@@ -624,4 +636,12 @@ fn gc_blob_table(
         let _ = table.remove(root.as_slice()).map_err(to_string)?;
     }
     Ok(to_delete.len())
+}
+
+/// Removes every key/value row from a bytes-keyed table.
+fn clear_bytes_table(
+    table: &mut redb::Table<'_, &'static [u8], &'static [u8]>,
+) -> Result<(), String> {
+    while table.pop_first().map_err(to_string)?.is_some() {}
+    Ok(())
 }

--- a/src/storage/canonical_db.rs
+++ b/src/storage/canonical_db.rs
@@ -290,6 +290,7 @@ impl CanonicalDb {
         state_index: &RapidHashMap<u64, Bytes32>,
         block_index: &RapidHashMap<u64, Bytes32>,
         state_root_index: &RapidHashMap<Bytes32, Bytes32>,
+        rewrite_state_root_index: bool,
         head: Option<Bytes32>,
         finalized: Option<Bytes32>,
         finalized_slot: Option<u64>,
@@ -314,7 +315,7 @@ impl CanonicalDb {
                     .map_err(to_string)?;
             }
         }
-        {
+        if rewrite_state_root_index {
             let mut state_root_table = write_txn
                 .open_table(STATE_ROOT_INDEX_TABLE)
                 .map_err(to_string)?;

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -330,6 +330,14 @@ impl FileStore {
     /// Flushes canonical indexes + metadata to canonical DB if dirty.
     #[inline]
     pub(super) fn flush_canonical(&mut self) -> Result<(), String> {
+        self.flush_canonical_with_state_root_index(true)
+    }
+
+    #[inline]
+    pub(super) fn flush_canonical_with_state_root_index(
+        &mut self,
+        rewrite_state_root_index: bool,
+    ) -> Result<(), String> {
         if !self.index_dirty && !self.meta_dirty {
             return Ok(());
         }
@@ -337,6 +345,7 @@ impl FileStore {
             &self.state_by_slot,
             &self.block_by_slot,
             &self.state_root_to_block_root,
+            rewrite_state_root_index,
             self.head,
             self.finalized,
             self.finalized_slot,

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -489,15 +489,22 @@ impl FileStore {
         let block_blob = encode_blob(BLOB_KIND_BLOCK, &block.encode_ssz());
         let signed_blob = encode_blob(BLOB_KIND_SIGNED_BLOCK, &signed.encode_ssz());
         let state_blob = encode_blob(BLOB_KIND_STATE, &persisted_state.encode_ssz());
-        self.state_root_to_block_root.insert(state_root, root);
-
-        if update_head {
-            self.head = Some(root);
-            self.justified = Some(meta_justified.root);
-            self.finalized = Some(meta_finalized.root);
-            self.finalized_slot = Some(meta_finalized.slot.0.0);
-            self.set_meta_dirty();
-        }
+        let next_head = if update_head { Some(root) } else { self.head };
+        let next_justified = if update_head {
+            Some(meta_justified.root)
+        } else {
+            self.justified
+        };
+        let next_finalized = if update_head {
+            Some(meta_finalized.root)
+        } else {
+            self.finalized
+        };
+        let next_finalized_slot = if update_head {
+            Some(meta_finalized.slot.0.0)
+        } else {
+            self.finalized_slot
+        };
 
         let counter = PERSIST_LOGS.get_or_init(|| AtomicUsize::new(0));
         if counter.fetch_add(1, Ordering::Relaxed) < 64 {
@@ -506,19 +513,19 @@ impl FileStore {
                 block_slot = slot,
                 parent_root = ?block.parent_root,
                 state_root = ?state_root,
-                head_root = ?self.head,
-                justified_root = ?self.justified,
-                finalized_root = ?self.finalized,
-                finalized_slot = self.finalized_slot.unwrap_or(0),
+                head_root = ?next_head,
+                justified_root = ?next_justified,
+                finalized_root = ?next_finalized,
+                finalized_slot = next_finalized_slot.unwrap_or(0),
                 state_slot = persisted_state.slot.0.0,
                 latest_header_slot = persisted_state.latest_block_header.slot.0.0,
                 "persisted signed block bundle"
             );
         }
 
-        let fin_slot = meta_finalized.slot.0.0;
-        let block_canonical = self.index_block_slot(slot, root, state_root);
-        self.index_state_slot(slot, state_root);
+        let fin_slot = next_finalized_slot.unwrap_or(0);
+        let block_canonical = !matches!(next_finalized_slot, Some(finalized_slot) if slot > finalized_slot);
+        let pending_promotions = self.pending_blocks.entries_leq(fin_slot);
 
         let mut state_upserts = Vec::new();
         let mut block_upserts = Vec::new();
@@ -526,15 +533,10 @@ impl FileStore {
         if block_canonical {
             block_upserts.push((slot, root));
         }
-        let block_by_slot = &mut self.block_by_slot;
-        let state_by_slot = &mut self.state_by_slot;
-        let pending = &mut self.pending_blocks;
-        pending.drain_leq_with(fin_slot, |value| {
-            block_by_slot.insert(value.slot, value.block_root);
-            state_by_slot.insert(value.slot, value.state_root);
+        for value in &pending_promotions {
             state_upserts.push((value.slot, value.state_root));
             block_upserts.push((value.slot, value.block_root));
-        });
+        }
 
         self.canonical_db.persist_signed_block_bundle(
             root,
@@ -544,11 +546,29 @@ impl FileStore {
             &state_blob,
             &state_upserts,
             &block_upserts,
-            self.head,
-            self.finalized,
-            self.finalized_slot,
-            self.justified,
+            next_head,
+            next_finalized,
+            next_finalized_slot,
+            next_justified,
         )?;
+
+        self.state_root_to_block_root.insert(state_root, root);
+        if update_head {
+            self.head = next_head;
+            self.justified = next_justified;
+            self.finalized = next_finalized;
+            self.finalized_slot = next_finalized_slot;
+        }
+        if block_canonical {
+            self.block_by_slot.insert(slot, root);
+        } else {
+            self.pending_blocks.insert(slot, root, state_root);
+        }
+        self.state_by_slot.insert(slot, state_root);
+        self.pending_blocks.drain_leq_with(fin_slot, |value| {
+            self.block_by_slot.insert(value.slot, value.block_root);
+            self.state_by_slot.insert(value.slot, value.state_root);
+        });
         self.index_dirty = false;
         self.meta_dirty = false;
         Ok(())
@@ -970,9 +990,9 @@ impl Store for FileStore {
     ///
     /// All three blobs (block, signed block, post-state) plus index/meta
     /// deltas are written in a single redb write transaction. If the
-    /// transaction commits, in-memory dirty flags are cleared. If it fails,
-    /// in-memory state is ahead of disk (recovered on next `flush_canonical`
-    /// or `Drop`).
+    /// transaction commits, the corresponding in-memory indexes and resolver
+    /// entries are published. If it fails, neither the durable nor the live
+    /// view is advanced.
     #[inline]
     fn put_signed_block(
         &mut self,

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -922,7 +922,10 @@ impl Store for FileStore {
     #[inline]
     fn put_state(&mut self, root: Bytes32, state: State) {
         let slot = state.slot.0.0;
-        let block_root = Bytes32::from(state.latest_block_header.hash_tree_root());
+        // Standalone `put_state` callers only provide a single root identity,
+        // so preserve that behavior by using the supplied root as the blob key
+        // and secondary lookup target.
+        let block_root = root;
         // Blob write must succeed before canonical indexes can reference this root.
         if self.persist_state(block_root, &state).is_err() {
             return;

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -590,9 +590,14 @@ impl FileStore {
         metrics: Option<&crate::metrics::MetricsRegistry>,
     ) -> Result<State, String> {
         let parent_root = signed.message.block.parent_root;
-        let _parent_block = self
-            .load_block_by_root(&parent_root)
-            .ok_or_else(|| "block parent root unknown in store".to_string())?;
+        let parent_exists = self
+            .canonical_db
+            .with_block_blob(parent_root, |_| Some(()))
+            .map_err(|err| err.to_string())?
+            .is_some();
+        if !parent_exists {
+            return Err("block parent root unknown in store".to_string());
+        }
         let mut parent_state = self
             .load_state_by_block_root(&parent_root)
             .ok_or_else(|| "parent state root missing in store".to_string())?;
@@ -1015,7 +1020,7 @@ impl Store for FileStore {
     /// By-slot state read: pending window (`O(1)`) → canonical index → cold path.
     fn get_state_by_slot(&self, slot: u64) -> Option<State> {
         if let Some(entry) = self.pending_blocks.get(slot) {
-            return self.load_state_by_identifier(&entry.state_root);
+            return self.load_state_by_block_root(&entry.block_root);
         }
         let root = self.state_by_slot.get(&slot).copied()?;
         self.load_state_by_identifier(&root)

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -336,6 +336,7 @@ impl FileStore {
         self.canonical_db.persist_snapshot(
             &self.state_by_slot,
             &self.block_by_slot,
+            &self.state_root_to_block_root,
             self.head,
             self.finalized,
             self.finalized_slot,

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -19,9 +19,9 @@
 //!
 //! | Method | Warm (in-memory) | Cold (redb) |
 //! |--------|------------------|-------------|
-//! | `get_state(root)` | — | redb read txn → decode blob → SSZ decode |
+//! | `get_state(root)` | — | state-root lookup → block-root blob decode |
 //! | `get_block(root)` | — | redb read txn → decode blob → SSZ decode |
-//! | `get_state_by_slot(slot)` | pending cache hit | slot index → root → cold path |
+//! | `get_state_by_slot(slot)` | pending cache hit | slot index → state-root lookup → cold path |
 //! | `get_block_by_slot(slot)` | pending cache hit | slot index → root → cold path |
 //!
 //! By-root reads always go to disk (no in-memory blob cache). By-slot reads
@@ -61,6 +61,8 @@ pub struct FileStore {
     pub(super) canonical_db: CanonicalDb,
     /// Canonical finalized slot->state-root index.
     pub(super) state_by_slot: RapidHashMap<u64, Bytes32>,
+    /// Secondary lookup from state root to the owning block root.
+    pub(super) state_root_to_block_root: RapidHashMap<Bytes32, Bytes32>,
     /// Canonical finalized slot->block-root index.
     pub(super) block_by_slot: RapidHashMap<u64, Bytes32>,
     /// Pending (non-finalized) slot->block-root cache.
@@ -225,6 +227,7 @@ impl FileStore {
             root,
             canonical_db,
             state_by_slot: RapidHashMap::default(),
+            state_root_to_block_root: RapidHashMap::default(),
             block_by_slot: RapidHashMap::default(),
             pending_blocks: PendingSlotCache::new(PENDING_WINDOW_CAP),
             head: None,
@@ -264,16 +267,23 @@ impl FileStore {
         self.pending_blocks.len()
     }
 
-    /// Cold-path state read: zero-copy from redb mmap → validate header →
-    /// SSZ decode. No intermediate heap allocation.
+    /// Cold-path state read by block root: zero-copy from redb mmap → validate
+    /// header → SSZ decode. No intermediate heap allocation.
     #[inline]
-    fn load_state_by_root(&self, root: &Bytes32) -> Option<State> {
+    fn load_state_by_block_root(&self, root: &Bytes32) -> Option<State> {
         self.canonical_db
             .with_state_blob(*root, |bytes| {
                 let off = decode_blob_offset(BLOB_KIND_STATE, bytes)?;
                 decode_state_safe(&bytes[off..])
             })
             .ok()?
+    }
+
+    /// State lookup that accepts either a state root or a block root.
+    #[inline]
+    fn load_state_by_identifier(&self, root: &Bytes32) -> Option<State> {
+        let block_root = self.state_root_to_block_root.get(root).copied().unwrap_or(*root);
+        self.load_state_by_block_root(&block_root)
     }
 
     /// Cold-path block read. Same zero-copy pipeline.
@@ -371,6 +381,15 @@ impl FileStore {
     fn load_from_disk(&mut self) -> Result<(), String> {
         self.load_state_index()?;
         self.load_block_index()?;
+        match self.canonical_db.load_state_root_index() {
+            Ok(index) => {
+                self.state_root_to_block_root = index;
+            }
+            Err(_) => {
+                self.state_root_to_block_root.clear();
+                self.recovery.skipped_corrupt += 1;
+            }
+        }
         self.load_meta()?;
         if self.finalized_slot.is_none() {
             self.finalized_slot = self
@@ -416,11 +435,11 @@ impl FileStore {
         self.meta_dirty = true;
     }
 
-    /// Writes a state blob to `canonical.redb`.
+    /// Writes a state blob to `canonical.redb`, keyed by block root.
     #[inline]
-    fn persist_state(&self, root: Bytes32, state: &State) -> Result<(), String> {
+    fn persist_state(&self, block_root: Bytes32, state: &State) -> Result<(), String> {
         let encoded = encode_blob(BLOB_KIND_STATE, &state.encode_ssz());
-        self.canonical_db.persist_state_blob(root, &encoded)
+        self.canonical_db.persist_state_blob(block_root, &encoded)
     }
 
     /// Writes a block blob to `canonical.redb`.
@@ -465,6 +484,7 @@ impl FileStore {
         let block_blob = encode_blob(BLOB_KIND_BLOCK, &block.encode_ssz());
         let signed_blob = encode_blob(BLOB_KIND_SIGNED_BLOCK, &signed.encode_ssz());
         let state_blob = encode_blob(BLOB_KIND_STATE, &persisted_state.encode_ssz());
+        self.state_root_to_block_root.insert(state_root, root);
 
         if update_head {
             self.head = Some(root);
@@ -536,11 +556,11 @@ impl FileStore {
         metrics: Option<&crate::metrics::MetricsRegistry>,
     ) -> Result<State, String> {
         let parent_root = signed.message.block.parent_root;
-        let parent_block = self
+        let _parent_block = self
             .load_block_by_root(&parent_root)
             .ok_or_else(|| "block parent root unknown in store".to_string())?;
         let mut parent_state = self
-            .load_state_by_root(&parent_block.state_root)
+            .load_state_by_block_root(&parent_root)
             .ok_or_else(|| "parent state root missing in store".to_string())?;
         if let Some(metrics) = metrics {
             parent_state.process_signed_block_with_metrics(signed, metrics)?;
@@ -572,7 +592,7 @@ impl FileStore {
             );
             return;
         };
-        let Some(parent_state) = self.load_state_by_root(&parent_block.state_root) else {
+        let Some(parent_state) = self.load_state_by_block_root(&parent_root) else {
             warn!(
                 block_root = ?root,
                 block_slot = block.slot.0.0,
@@ -896,16 +916,25 @@ impl Drop for FileStore {
 impl Store for FileStore {
     #[inline]
     fn get_state(&self, root: &Bytes32) -> Option<State> {
-        self.load_state_by_root(root)
+        self.load_state_by_identifier(root)
     }
 
     #[inline]
     fn put_state(&mut self, root: Bytes32, state: State) {
         let slot = state.slot.0.0;
+        let block_root = Bytes32::from(state.latest_block_header.hash_tree_root());
         // Blob write must succeed before canonical indexes can reference this root.
-        if self.persist_state(root, &state).is_err() {
+        if self.persist_state(block_root, &state).is_err() {
             return;
         }
+        if self
+            .canonical_db
+            .persist_state_root_mapping(root, block_root)
+            .is_err()
+        {
+            return;
+        }
+        self.state_root_to_block_root.insert(root, block_root);
         self.index_state_slot(slot, root);
     }
 
@@ -949,10 +978,10 @@ impl Store for FileStore {
     /// By-slot state read: pending window (`O(1)`) → canonical index → cold path.
     fn get_state_by_slot(&self, slot: u64) -> Option<State> {
         if let Some(entry) = self.pending_blocks.get(slot) {
-            return self.load_state_by_root(&entry.state_root);
+            return self.load_state_by_identifier(&entry.state_root);
         }
         let root = self.state_by_slot.get(&slot).copied()?;
-        self.load_state_by_root(&root)
+        self.load_state_by_identifier(&root)
     }
 
     /// By-slot block read: pending window (`O(1)`) → canonical index → cold path.

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -385,7 +385,11 @@ impl FileStore {
             Ok(index) => {
                 self.state_root_to_block_root = index;
             }
-            Err(_) => {
+            Err(err) => {
+                warn!(
+                    %err,
+                    "failed to load state-root index; continuing with an empty mapping may require state reindexing and can reduce blob-retention accuracy until rebuilt"
+                );
                 self.state_root_to_block_root.clear();
                 self.recovery.skipped_corrupt += 1;
             }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -49,7 +49,7 @@ const PENDING_WINDOW_CAP: usize = 2_048;
 /// Schema version file name.
 const SCHEMA_FILE: &str = "schema_version";
 /// Current on-disk schema version string.
-const SCHEMA_VERSION: &str = "1";
+const SCHEMA_VERSION: &str = "2";
 /// Magic bytes at the start of every blob file.
 const BLOB_MAGIC: &[u8; 8] = b"LEANSTRG";
 /// Blob format version byte.

--- a/src/storage/pending.rs
+++ b/src/storage/pending.rs
@@ -113,6 +113,17 @@ impl PendingSlotCache {
         }
     }
 
+    /// Returns a snapshot of entries with `slot <= upper_inclusive`.
+    #[inline]
+    pub(super) fn entries_leq(&self, upper_inclusive: u64) -> Vec<PendingEntry> {
+        self.entries
+            .iter()
+            .flatten()
+            .copied()
+            .filter(|entry| entry.slot <= upper_inclusive)
+            .collect()
+    }
+
     /// Retains only entries for which `keep(slot, block_root, state_root)` returns `true`.
     #[allow(dead_code)]
     pub(super) fn retain<F>(&mut self, mut keep: F)

--- a/src/storage/pending.rs
+++ b/src/storage/pending.rs
@@ -154,4 +154,14 @@ impl PendingSlotCache {
             state_block_roots.insert(entry.block_root);
         }
     }
+
+    /// Extends a retention set with the state roots of all buffered pending entries.
+    pub(super) fn extend_referenced_state_roots(
+        &self,
+        state_roots: &mut rapidhash::RapidHashSet<Bytes32>,
+    ) {
+        for entry in self.entries.iter().flatten() {
+            state_roots.insert(entry.state_root);
+        }
+    }
 }

--- a/src/storage/pending.rs
+++ b/src/storage/pending.rs
@@ -147,11 +147,11 @@ impl PendingSlotCache {
     pub(super) fn extend_referenced_roots(
         &self,
         block_roots: &mut rapidhash::RapidHashSet<Bytes32>,
-        state_roots: &mut rapidhash::RapidHashSet<Bytes32>,
+        state_block_roots: &mut rapidhash::RapidHashSet<Bytes32>,
     ) {
         for entry in self.entries.iter().flatten() {
             block_roots.insert(entry.block_root);
-            state_roots.insert(entry.state_root);
+            state_block_roots.insert(entry.block_root);
         }
     }
 }

--- a/src/storage/prune.rs
+++ b/src/storage/prune.rs
@@ -1,6 +1,6 @@
 use super::*;
 use rapidhash::RapidHashSet;
-use tracing::info;
+use tracing::{info, warn};
 
 /// Statistics returned by [`FileStore::prune`].
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -75,9 +75,17 @@ impl FileStore {
         self.flush_canonical()?;
 
         let mut keep_state_block_roots = RapidHashSet::<Bytes32>::default();
+        let mut missing_state_root_mappings = 0usize;
         for state_root in self.state_by_slot.values().copied() {
             if let Some(block_root) = self.state_root_to_block_root.get(&state_root).copied() {
                 keep_state_block_roots.insert(block_root);
+            } else {
+                // Standalone `put_state` callers key state blobs directly by the
+                // provided root, so keep that root too. If the missing mapping
+                // belongs to migrated/imported state, we treat prune
+                // conservatively below and retain all state blobs for this pass.
+                keep_state_block_roots.insert(state_root);
+                missing_state_root_mappings += 1;
             }
         }
         let mut keep_block_roots = RapidHashSet::<Bytes32>::default();
@@ -86,6 +94,14 @@ impl FileStore {
         keep_state_block_roots.extend(pinned.iter().flatten().copied());
         self.pending_blocks
             .extend_referenced_roots(&mut keep_block_roots, &mut keep_state_block_roots);
+
+        if missing_state_root_mappings > 0 {
+            warn!(
+                missing_state_root_mappings,
+                "state-root mapping is incomplete; skipping state-blob garbage collection for this prune pass to avoid deleting retained state"
+            );
+            keep_state_block_roots.extend(self.canonical_db.load_state_blob_roots()?);
+        }
 
         let gc = self
             .canonical_db

--- a/src/storage/prune.rs
+++ b/src/storage/prune.rs
@@ -58,6 +58,13 @@ impl FileStore {
             false
         });
 
+        let mut live_state_roots = RapidHashSet::<Bytes32>::default();
+        live_state_roots.extend(self.state_by_slot.values().copied());
+        self.pending_blocks
+            .extend_referenced_state_roots(&mut live_state_roots);
+        self.state_root_to_block_root
+            .retain(|state_root, _| live_state_roots.contains(state_root));
+
         // Canonical block index prune.
         self.block_by_slot.retain(|slot, root| {
             if *slot >= prune_before {

--- a/src/storage/prune.rs
+++ b/src/storage/prune.rs
@@ -74,17 +74,22 @@ impl FileStore {
         self.index_dirty = true;
         self.flush_canonical()?;
 
-        let mut keep_state_roots = RapidHashSet::<Bytes32>::default();
-        keep_state_roots.extend(self.state_by_slot.values().copied());
+        let mut keep_state_block_roots = RapidHashSet::<Bytes32>::default();
+        for state_root in self.state_by_slot.values().copied() {
+            if let Some(block_root) = self.state_root_to_block_root.get(&state_root).copied() {
+                keep_state_block_roots.insert(block_root);
+            }
+        }
         let mut keep_block_roots = RapidHashSet::<Bytes32>::default();
         keep_block_roots.extend(self.block_by_slot.values().copied());
         keep_block_roots.extend(pinned.iter().flatten().copied());
+        keep_state_block_roots.extend(pinned.iter().flatten().copied());
         self.pending_blocks
-            .extend_referenced_roots(&mut keep_block_roots, &mut keep_state_roots);
+            .extend_referenced_roots(&mut keep_block_roots, &mut keep_state_block_roots);
 
         let gc = self
             .canonical_db
-            .gc_unreferenced_blobs(&keep_state_roots, &keep_block_roots)?;
+            .gc_unreferenced_blobs(&keep_state_block_roots, &keep_block_roots)?;
         report.removed_state_blobs = gc.removed_state_blobs;
         report.removed_block_blobs = gc.removed_block_blobs;
         report.removed_signed_blocks = gc.removed_signed_block_blobs;

--- a/src/storage/prune.rs
+++ b/src/storage/prune.rs
@@ -62,8 +62,19 @@ impl FileStore {
         live_state_roots.extend(self.state_by_slot.values().copied());
         self.pending_blocks
             .extend_referenced_state_roots(&mut live_state_roots);
-        self.state_root_to_block_root
-            .retain(|state_root, _| live_state_roots.contains(state_root));
+        let missing_state_root_mappings = live_state_roots
+            .iter()
+            .filter(|state_root| !self.state_root_to_block_root.contains_key(*state_root))
+            .count();
+        if missing_state_root_mappings == 0 {
+            self.state_root_to_block_root
+                .retain(|state_root, _| live_state_roots.contains(state_root));
+        } else {
+            warn!(
+                missing_state_root_mappings,
+                "state-root mapping is incomplete; skipping state-root index rewrite for this prune pass to preserve existing lookups"
+            );
+        }
 
         // Canonical block index prune.
         self.block_by_slot.retain(|slot, root| {
@@ -79,10 +90,9 @@ impl FileStore {
         });
 
         self.index_dirty = true;
-        self.flush_canonical()?;
+        self.flush_canonical_with_state_root_index(missing_state_root_mappings == 0)?;
 
         let mut keep_state_block_roots = RapidHashSet::<Bytes32>::default();
-        let mut missing_state_root_mappings = 0usize;
         for state_root in self.state_by_slot.values().copied() {
             if let Some(block_root) = self.state_root_to_block_root.get(&state_root).copied() {
                 keep_state_block_roots.insert(block_root);
@@ -92,7 +102,6 @@ impl FileStore {
                 // belongs to migrated/imported state, we treat prune
                 // conservatively below and retain all state blobs for this pass.
                 keep_state_block_roots.insert(state_root);
-                missing_state_root_mappings += 1;
             }
         }
         let mut keep_block_roots = RapidHashSet::<Bytes32>::default();

--- a/src/storage/storage_utils.rs
+++ b/src/storage/storage_utils.rs
@@ -123,7 +123,8 @@ pub(super) fn decode_blob_offset(expected_kind: u8, bytes: &[u8]) -> Option<usiz
 ///
 /// If the file does not exist it is created with the current version. If it
 /// exists with a different version an error is returned, indicating that the
-/// data directory was written by an incompatible binary.
+/// data directory was written by an incompatible binary and must be migrated or
+/// recreated before startup can continue.
 ///
 /// # Errors
 ///
@@ -138,7 +139,7 @@ pub(super) fn ensure_schema_version(root: &Path) -> Result<(), String> {
     let value = fs::read_to_string(schema_path).map_err(|err| err.to_string())?;
     if value.trim() != SCHEMA_VERSION {
         return Err(format!(
-            "unsupported storage schema version {}, expected {}",
+            "unsupported storage schema version {}, expected {}; this binary cannot open older data directories in place, so migrate the store or recreate the data directory",
             value.trim(),
             SCHEMA_VERSION
         ));


### PR DESCRIPTION
fix persistence state bug by storing use block root instead of state root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped storage schema to v2 and added a persisted mapping between state and block identifiers.
* **Refactor**
  * State blobs are now stored and referenced by block identifiers; cold-path loading accepts either state or block identifiers and resolves them at startup.
* **Bug Fixes**
  * GC/retention updated to preserve states by block references; startup loads mappings, warns and recovers on corruption, and disables state-blob GC when mappings are incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->