### PR TITLE
Feat(Storage): fix state storage block root

### DIFF
--- a/src/node/gossip.rs
+++ b/src/node/gossip.rs
@@ -298,7 +298,7 @@ pub fn handle_gossip_event<S: Store + Send + Sync + 'static>(
                     // Use the block's exact post-state for fork choice, not
                     // the live state — the replay fallback may have diverged.
                     let fc_state = store_guard
-                        .get_state(&signed.message.block.state_root)
+                        .get_state(&root)
                         .unwrap_or_else(|| state_guard.clone());
                     let mut fc = fork_choice.write().expect("fork choice lock");
                     if fc.is_none() {

--- a/src/node/sync/backfill.rs
+++ b/src/node/sync/backfill.rs
@@ -80,7 +80,7 @@ pub(super) fn import_backfill_chain(
     } else {
         match store_guard.get_block(&parent_root) {
             Some(parent_block) => {
-                if let Some(parent_state) = store_guard.get_state(&parent_block.state_root) {
+                if let Some(parent_state) = store_guard.get_state(&parent_root) {
                     parent_state
                 } else {
                     warn!(

--- a/src/node/sync/backfill.rs
+++ b/src/node/sync/backfill.rs
@@ -80,14 +80,11 @@ pub(super) fn import_backfill_chain(
     } else {
         match store_guard.get_block(&parent_root) {
             Some(parent_block) => {
-                if let Some(parent_state) = store_guard
-                    .get_state(&parent_root)
-                    .or_else(|| store_guard.get_state(&parent_block.state_root))
-                {
+                if let Some(parent_state) = store_guard.get_state(&parent_root) {
                     parent_state
                 } else {
                     warn!(
-                        "sync import fallback: parent state missing state_root={:?} parent_block={parent_root:?}, using anchor state",
+                        "sync import fallback: parent state missing root={:?} parent_block={parent_root:?}, using anchor state",
                         parent_block.state_root
                     );
                     sync_anchor_state.clone()

--- a/src/node/sync/backfill.rs
+++ b/src/node/sync/backfill.rs
@@ -80,11 +80,14 @@ pub(super) fn import_backfill_chain(
     } else {
         match store_guard.get_block(&parent_root) {
             Some(parent_block) => {
-                if let Some(parent_state) = store_guard.get_state(&parent_root) {
+                if let Some(parent_state) = store_guard
+                    .get_state(&parent_root)
+                    .or_else(|| store_guard.get_state(&parent_block.state_root))
+                {
                     parent_state
                 } else {
                     warn!(
-                        "sync import fallback: parent state missing root={:?} parent_block={parent_root:?}, using anchor state",
+                        "sync import fallback: parent state missing state_root={:?} parent_block={parent_root:?}, using anchor state",
                         parent_block.state_root
                     );
                     sync_anchor_state.clone()

--- a/src/storage/canonical_db.rs
+++ b/src/storage/canonical_db.rs
@@ -9,7 +9,7 @@
 //! ┌────────────────────────────┬──────────────┬───────────────────────────┐
 //! │ Table                      │ Key          │ Value                     │
 //! ├────────────────────────────┼──────────────┼───────────────────────────┤
-//! │ canonical_state_slot       │ u64 (slot)   │ [u8] (Bytes32 root)       │
+//! │ canonical_state_slot       │ u64 (slot)   │ [u8] (Bytes32 block root) │
 //! │ canonical_block_slot       │ u64 (slot)   │ [u8] (Bytes32 root)       │
 //! │ canonical_meta             │ &str (key)   │ [u8] (Bytes32 root)       │
 //! │ canonical_state_root_index │ [u8]         │ [u8] (block root)         │
@@ -19,7 +19,7 @@
 //! └────────────────────────────┴──────────────┴───────────────────────────┘
 //! ```
 //!
-//! Slot tables map `slot → root` (canonical index). `canonical_state_root_index`
+//! Slot tables map `slot → block_root` (canonical index). `canonical_state_root_index`
 //! maps `state_root → block_root`. Blob tables map `root → envelope` (the
 //! actual serialized data). Meta stores three
 //! string-keyed roots: `"head"`, `"finalized"`, `"justified"`, plus
@@ -39,7 +39,7 @@ use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 
 use super::Bytes32;
 
-/// Canonical state slot index: `slot → Bytes32 state root`.
+/// Canonical state slot index: `slot → Bytes32 block root`.
 const STATE_SLOT_TABLE: TableDefinition<'static, u64, &'static [u8]> =
     TableDefinition::new("canonical_state_slot");
 /// Canonical block slot index: `slot → Bytes32 block root`.
@@ -169,18 +169,6 @@ impl CanonicalDb {
                 bytes_to_root(state_root.value())?,
                 bytes_to_root(block_root.value())?,
             );
-        }
-        Ok(out)
-    }
-
-    /// Loads every state-blob key currently present in canonical storage.
-    pub(super) fn load_state_blob_roots(&self) -> Result<RapidHashSet<Bytes32>, String> {
-        let read_txn = self.db.begin_read().map_err(to_string)?;
-        let table = read_txn.open_table(STATE_BLOB_TABLE).map_err(to_string)?;
-        let mut out = RapidHashSet::default();
-        for row in table.iter().map_err(to_string)? {
-            let (root, _) = row.map_err(to_string)?;
-            out.insert(bytes_to_root(root.value())?);
         }
         Ok(out)
     }
@@ -341,7 +329,7 @@ impl CanonicalDb {
     /// Unlike [`persist_snapshot`] this does **not** clear-and-rewrite the
     /// slot tables. Instead it:
     /// 1. Inserts the three blobs (state, block, signed block) by root.
-    /// 2. Upserts only the changed slot→root rows (`state_upserts`,
+    /// 2. Upserts only the changed slot→block-root rows (`state_upserts`,
     ///    `block_upserts`) — the new block plus any promoted pending entries.
     /// 3. Upserts metadata (head, finalized, justified).
     ///

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -19,9 +19,9 @@
 //!
 //! | Method | Warm (in-memory) | Cold (redb) |
 //! |--------|------------------|-------------|
-//! | `get_state(root)` | — | state-root lookup → block-root blob decode |
+//! | `get_state(root)` | — | identifier compatibility lookup → block-root blob decode |
 //! | `get_block(root)` | — | redb read txn → decode blob → SSZ decode |
-//! | `get_state_by_slot(slot)` | pending cache hit | slot index → state-root lookup → cold path |
+//! | `get_state_by_slot(slot)` | pending cache hit | slot index → block-root decode |
 //! | `get_block_by_slot(slot)` | pending cache hit | slot index → root → cold path |
 //!
 //! By-root reads always go to disk (no in-memory blob cache). By-slot reads
@@ -50,7 +50,7 @@ use crate::ssz::{HashTreeRoot, SszEncode};
 /// A disk-backed [`Store`] with canonical+pending slot indexes as truth.
 ///
 /// Index model:
-/// - `state_by_slot` / `block_by_slot`: canonical slot indexes.
+/// - `state_by_slot` / `block_by_slot`: canonical slot indexes keyed by block root.
 /// - `pending_blocks`: hot non-finalized block slot index (in-memory only).
 ///
 /// Object reads by root are decoded on demand from `canonical.redb`.
@@ -59,7 +59,7 @@ pub struct FileStore {
     pub(super) root: PathBuf,
     /// Canonical index + fork-choice metadata database.
     pub(super) canonical_db: CanonicalDb,
-    /// Canonical finalized slot->state-root index.
+    /// Canonical finalized slot->block-root index used for state lookup.
     pub(super) state_by_slot: RapidHashMap<u64, Bytes32>,
     /// Secondary lookup from state root to the owning block root.
     pub(super) state_root_to_block_root: RapidHashMap<Bytes32, Bytes32>,
@@ -316,7 +316,7 @@ impl FileStore {
         let pending = &mut self.pending_blocks;
         pending.drain_leq_with(finalized_slot, |value| {
             block_by_slot.insert(value.slot, value.block_root);
-            state_by_slot.insert(value.slot, value.state_root);
+            state_by_slot.insert(value.slot, value.block_root);
         });
     }
 
@@ -356,7 +356,7 @@ impl FileStore {
         Ok(())
     }
 
-    /// Records a state root in the canonical slot index and marks dirty.
+    /// Records a block root in the canonical state slot index and marks dirty.
     #[inline]
     fn index_state_slot(&mut self, slot: u64, root: Bytes32) {
         self.state_by_slot.insert(slot, root);
@@ -368,10 +368,10 @@ impl FileStore {
     /// Returns `true` if routed to canonical (slot ≤ finalized), `false` if
     /// buffered in the pending window (slot > finalized).
     #[inline]
-    fn index_block_slot(&mut self, slot: u64, root: Bytes32, state_root: Bytes32) -> bool {
+    fn index_block_slot(&mut self, slot: u64, root: Bytes32) -> bool {
         match self.finalized_slot {
             Some(finalized_slot) if slot > finalized_slot => {
-                self.pending_blocks.insert(slot, root, state_root);
+                self.pending_blocks.insert(slot, root);
                 false
             }
             _ => {
@@ -420,6 +420,29 @@ impl FileStore {
     #[inline]
     pub(super) fn pinned_roots(&self) -> [Option<Bytes32>; 3] {
         [self.head, self.justified, self.finalized]
+    }
+
+    /// Rebuilds the compatibility lookup from the currently live block roots.
+    ///
+    /// Canonical slot indexes and the pending window are block-root-native, so
+    /// this path is only needed to preserve `get_state(state_root)` callers.
+    pub(super) fn rebuild_live_state_root_index(&self) -> RapidHashMap<Bytes32, Bytes32> {
+        let mut live_block_roots = rapidhash::RapidHashSet::<Bytes32>::default();
+        live_block_roots.extend(self.state_by_slot.values().copied());
+        live_block_roots.extend(self.pending_blocks.roots());
+        live_block_roots.extend(self.pinned_roots().iter().flatten().copied());
+
+        let mut live_index = RapidHashMap::default();
+        for block_root in live_block_roots {
+            if let Some(block) = self.load_block_by_root(&block_root) {
+                live_index.insert(block.state_root, block_root);
+            } else if self.load_state_by_block_root(&block_root).is_some() {
+                // Standalone `put_state` stores use the provided root as both
+                // the blob key and the compatibility lookup key.
+                live_index.insert(block_root, block_root);
+            }
+        }
+        live_index
     }
 
     /// Loads fork-choice metadata (`head`, `finalized`, `justified`) from canonical DB.
@@ -495,6 +518,17 @@ impl FileStore {
         let block = signed.message.block.clone();
         let slot = block.slot.0.0;
         let state_root = block.state_root;
+        let adjusted_state = if persisted_state.latest_justified == meta_justified
+            && persisted_state.latest_finalized == meta_finalized
+        {
+            None
+        } else {
+            let mut state = persisted_state.clone();
+            state.latest_justified = meta_justified;
+            state.latest_finalized = meta_finalized;
+            Some(state)
+        };
+        let persisted_state = adjusted_state.as_ref().unwrap_or(persisted_state);
         let block_blob = encode_blob(BLOB_KIND_BLOCK, &block.encode_ssz());
         let signed_blob = encode_blob(BLOB_KIND_SIGNED_BLOCK, &signed.encode_ssz());
         let state_blob = encode_blob(BLOB_KIND_STATE, &persisted_state.encode_ssz());
@@ -538,12 +572,12 @@ impl FileStore {
 
         let mut state_upserts = Vec::new();
         let mut block_upserts = Vec::new();
-        state_upserts.push((slot, state_root));
+        state_upserts.push((slot, root));
         if block_canonical {
             block_upserts.push((slot, root));
         }
         for value in &pending_promotions {
-            state_upserts.push((value.slot, value.state_root));
+            state_upserts.push((value.slot, value.block_root));
             block_upserts.push((value.slot, value.block_root));
         }
 
@@ -571,12 +605,12 @@ impl FileStore {
         if block_canonical {
             self.block_by_slot.insert(slot, root);
         } else {
-            self.pending_blocks.insert(slot, root, state_root);
+            self.pending_blocks.insert(slot, root);
         }
-        self.state_by_slot.insert(slot, state_root);
+        self.state_by_slot.insert(slot, root);
         self.pending_blocks.drain_leq_with(fin_slot, |value| {
             self.block_by_slot.insert(value.slot, value.block_root);
-            self.state_by_slot.insert(value.slot, value.state_root);
+            self.state_by_slot.insert(value.slot, value.block_root);
         });
         self.index_dirty = false;
         self.meta_dirty = false;
@@ -977,7 +1011,7 @@ impl Store for FileStore {
             return;
         }
         self.state_root_to_block_root.insert(root, block_root);
-        self.index_state_slot(slot, root);
+        self.index_state_slot(slot, block_root);
     }
 
     #[inline]
@@ -992,12 +1026,11 @@ impl Store for FileStore {
     #[inline]
     fn put_block(&mut self, root: Bytes32, block: Block) {
         let slot = block.slot.0.0;
-        let state_root = block.state_root;
         // Blob write must succeed before canonical indexes can reference this root.
         if self.persist_block(root, &block).is_err() {
             return;
         }
-        self.index_block_slot(slot, root, state_root);
+        self.index_block_slot(slot, root);
     }
 
     /// Hot write path: state transition → encode → index → atomic persist.
@@ -1023,7 +1056,7 @@ impl Store for FileStore {
             return self.load_state_by_block_root(&entry.block_root);
         }
         let root = self.state_by_slot.get(&slot).copied()?;
-        self.load_state_by_identifier(&root)
+        self.load_state_by_block_root(&root)
     }
 
     /// By-slot block read: pending window (`O(1)`) → canonical index → cold path.

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -279,7 +279,10 @@ impl FileStore {
             .ok()?
     }
 
-    /// State lookup that accepts either a state root or a block root.
+    /// Compatibility lookup that accepts either a state root or a block root.
+    ///
+    /// The primary storage identity is block-root keyed. State-root lookup is
+    /// retained only to support older callers and external compatibility paths.
     #[inline]
     fn load_state_by_identifier(&self, root: &Bytes32) -> Option<State> {
         let block_root = self.state_root_to_block_root.get(root).copied().unwrap_or(*root);
@@ -995,22 +998,21 @@ impl Store for FileStore {
     #[inline]
     fn put_state(&mut self, root: Bytes32, state: State) {
         let slot = state.slot.0.0;
-        // Standalone `put_state` callers only provide a single root identity,
-        // so preserve that behavior by using the supplied root as the blob key
-        // and secondary lookup target.
+        // `put_state` is keyed by the owning block root.
         let block_root = root;
+        let state_root = Bytes32::from(state.hash_tree_root());
         // Blob write must succeed before canonical indexes can reference this root.
         if self.persist_state(block_root, &state).is_err() {
             return;
         }
         if self
             .canonical_db
-            .persist_state_root_mapping(root, block_root)
+            .persist_state_root_mapping(state_root, block_root)
             .is_err()
         {
             return;
         }
-        self.state_root_to_block_root.insert(root, block_root);
+        self.state_root_to_block_root.insert(state_root, block_root);
         self.index_state_slot(slot, block_root);
     }
 
@@ -1053,9 +1055,7 @@ impl Store for FileStore {
     /// By-slot state read: pending window (`O(1)`) → canonical index → cold path.
     fn get_state_by_slot(&self, slot: u64) -> Option<State> {
         if let Some(entry) = self.pending_blocks.get(slot) {
-            return self
-                .load_state_by_block_root(&entry.block_root)
-                .or_else(|| self.load_state_by_identifier(&entry.block_root));
+            return self.load_state_by_block_root(&entry.block_root);
         }
         let root = self.state_by_slot.get(&slot).copied()?;
         self.load_state_by_block_root(&root)

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -1053,7 +1053,9 @@ impl Store for FileStore {
     /// By-slot state read: pending window (`O(1)`) → canonical index → cold path.
     fn get_state_by_slot(&self, slot: u64) -> Option<State> {
         if let Some(entry) = self.pending_blocks.get(slot) {
-            return self.load_state_by_block_root(&entry.block_root);
+            return self
+                .load_state_by_block_root(&entry.block_root)
+                .or_else(|| self.load_state_by_identifier(&entry.block_root));
         }
         let root = self.state_by_slot.get(&slot).copied()?;
         self.load_state_by_block_root(&root)

--- a/src/storage/index_store.rs
+++ b/src/storage/index_store.rs
@@ -13,7 +13,7 @@ pub struct ForkChoiceMeta {
 /// Batched index/meta updates to apply atomically in a backend.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct IndexBatch {
-    pub state_upserts: Vec<(u64, Bytes32)>,
+    pub state_block_upserts: Vec<(u64, Bytes32)>,
     pub block_upserts: Vec<(u64, Bytes32)>,
     pub state_deletes: Vec<u64>,
     pub block_deletes: Vec<u64>,
@@ -24,9 +24,9 @@ pub struct IndexBatch {
 ///
 /// This is the abstraction point for a custom ClickHouse-style LSM backend.
 pub trait IndexStore {
-    fn get_state_root_by_slot(&self, slot: u64) -> Option<Bytes32>;
+    fn get_state_block_root_by_slot(&self, slot: u64) -> Option<Bytes32>;
     fn get_block_root_by_slot(&self, slot: u64) -> Option<Bytes32>;
-    fn iter_state_slots_lt(&self, upper_exclusive: u64) -> Vec<(u64, Bytes32)>;
+    fn iter_state_block_slots_lt(&self, upper_exclusive: u64) -> Vec<(u64, Bytes32)>;
     fn iter_block_slots_lt(&self, upper_exclusive: u64) -> Vec<(u64, Bytes32)>;
     fn get_meta(&self) -> ForkChoiceMeta;
     fn apply_batch(&mut self, batch: IndexBatch) -> Result<(), String>;
@@ -35,7 +35,7 @@ pub trait IndexStore {
 /// In-memory reference implementation of [`IndexStore`].
 #[derive(Default)]
 pub struct MemoryIndexStore {
-    state_by_slot: BTreeMap<u64, Bytes32>,
+    state_block_by_slot: BTreeMap<u64, Bytes32>,
     block_by_slot: BTreeMap<u64, Bytes32>,
     meta: ForkChoiceMeta,
 }
@@ -47,16 +47,16 @@ impl MemoryIndexStore {
 }
 
 impl IndexStore for MemoryIndexStore {
-    fn get_state_root_by_slot(&self, slot: u64) -> Option<Bytes32> {
-        self.state_by_slot.get(&slot).copied()
+    fn get_state_block_root_by_slot(&self, slot: u64) -> Option<Bytes32> {
+        self.state_block_by_slot.get(&slot).copied()
     }
 
     fn get_block_root_by_slot(&self, slot: u64) -> Option<Bytes32> {
         self.block_by_slot.get(&slot).copied()
     }
 
-    fn iter_state_slots_lt(&self, upper_exclusive: u64) -> Vec<(u64, Bytes32)> {
-        self.state_by_slot
+    fn iter_state_block_slots_lt(&self, upper_exclusive: u64) -> Vec<(u64, Bytes32)> {
+        self.state_block_by_slot
             .range(..upper_exclusive)
             .map(|(slot, root)| (*slot, *root))
             .collect()
@@ -74,14 +74,14 @@ impl IndexStore for MemoryIndexStore {
     }
 
     fn apply_batch(&mut self, batch: IndexBatch) -> Result<(), String> {
-        for (slot, root) in batch.state_upserts {
-            self.state_by_slot.insert(slot, root);
+        for (slot, root) in batch.state_block_upserts {
+            self.state_block_by_slot.insert(slot, root);
         }
         for (slot, root) in batch.block_upserts {
             self.block_by_slot.insert(slot, root);
         }
         for slot in batch.state_deletes {
-            self.state_by_slot.remove(&slot);
+            self.state_block_by_slot.remove(&slot);
         }
         for slot in batch.block_deletes {
             self.block_by_slot.remove(&slot);
@@ -105,7 +105,7 @@ mod tests {
     fn batch_upsert_delete_and_meta_roundtrip() {
         let mut store = MemoryIndexStore::new();
         let batch = IndexBatch {
-            state_upserts: vec![(10, root(1)), (20, root(2))],
+            state_block_upserts: vec![(10, root(1)), (20, root(2))],
             block_upserts: vec![(10, root(3)), (30, root(4))],
             state_deletes: vec![],
             block_deletes: vec![],
@@ -117,7 +117,7 @@ mod tests {
         };
         store.apply_batch(batch).expect("apply batch");
 
-        assert_eq!(store.get_state_root_by_slot(10), Some(root(1)));
+        assert_eq!(store.get_state_block_root_by_slot(10), Some(root(1)));
         assert_eq!(store.get_block_root_by_slot(30), Some(root(4)));
         assert_eq!(
             store.get_meta(),
@@ -129,14 +129,14 @@ mod tests {
         );
 
         let delete_batch = IndexBatch {
-            state_upserts: vec![],
+            state_block_upserts: vec![],
             block_upserts: vec![],
             state_deletes: vec![10],
             block_deletes: vec![30],
             meta: None,
         };
         store.apply_batch(delete_batch).expect("apply delete batch");
-        assert_eq!(store.get_state_root_by_slot(10), None);
+        assert_eq!(store.get_state_block_root_by_slot(10), None);
         assert_eq!(store.get_block_root_by_slot(30), None);
     }
 
@@ -145,7 +145,7 @@ mod tests {
         let mut store = MemoryIndexStore::new();
         store
             .apply_batch(IndexBatch {
-                state_upserts: vec![(4, root(4)), (1, root(1)), (3, root(3))],
+                state_block_upserts: vec![(4, root(4)), (1, root(1)), (3, root(3))],
                 block_upserts: vec![(6, root(6)), (2, root(2))],
                 state_deletes: vec![],
                 block_deletes: vec![],
@@ -154,7 +154,7 @@ mod tests {
             .expect("apply batch");
 
         assert_eq!(
-            store.iter_state_slots_lt(4),
+            store.iter_state_block_slots_lt(4),
             vec![(1, root(1)), (3, root(3))]
         );
         assert_eq!(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -83,9 +83,16 @@ pub struct RecoveryReport {
 /// Canonical lookup is slot-driven (`get_*_by_slot`). Root-driven lookups
 /// (`get_*`) also reach non-canonical fork data in [`FileStore`].
 pub trait Store {
-    /// Returns a decoded state for `root`, or `None` if not found/decoding fails.
+    /// Returns a decoded state for the owning block root `root`, or `None` if
+    /// not found/decoding fails.
+    ///
+    /// Implementations may preserve compatibility with state-root lookup, but
+    /// the intended storage contract is block-root-first.
     fn get_state(&self, root: &Bytes32) -> Option<State>;
-    /// Inserts or replaces the state keyed by `root`.
+    ///
+    /// `root` should be the owning block root for this post-state. Implementations
+    /// may preserve limited compatibility with older callers that pass a state
+    /// root here, but the intended storage contract is block-root-first.
     fn put_state(&mut self, root: Bytes32, state: State);
     /// Returns a decoded block for `root`, or `None` if not found/decoding fails.
     fn get_block(&self, root: &Bytes32) -> Option<Block>;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -49,7 +49,7 @@ const PENDING_WINDOW_CAP: usize = 2_048;
 /// Schema version file name.
 const SCHEMA_FILE: &str = "schema_version";
 /// Current on-disk schema version string.
-const SCHEMA_VERSION: &str = "2";
+const SCHEMA_VERSION: &str = "3";
 /// Magic bytes at the start of every blob file.
 const BLOB_MAGIC: &[u8; 8] = b"LEANSTRG";
 /// Blob format version byte.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -24,6 +24,7 @@
 
 use rapidhash::RapidHashMap;
 use tracing::warn;
+use peam_ssz::ssz::HashTreeRoot;
 
 use crate::containers::block::{Block, SignedBlockWithAttestation};
 use crate::containers::checkpoint::Checkpoint;
@@ -152,6 +153,7 @@ pub trait Store {
 #[derive(Default)]
 pub struct MemoryStore {
     states: RapidHashMap<Bytes32, State>,
+    state_root_to_block_root: RapidHashMap<Bytes32, Bytes32>,
     blocks: RapidHashMap<Bytes32, Block>,
     signed_blocks: RapidHashMap<Bytes32, SignedBlockWithAttestation>,
     state_by_slot: RapidHashMap<u64, Bytes32>,
@@ -172,12 +174,17 @@ impl MemoryStore {
 /// [`Store`] implementation for [`MemoryStore`].
 impl Store for MemoryStore {
     fn get_state(&self, root: &Bytes32) -> Option<State> {
-        self.states.get(root).cloned()
+        let block_root = self.state_root_to_block_root.get(root).copied().unwrap_or(*root);
+        self.states.get(&block_root).cloned()
     }
 
     fn put_state(&mut self, root: Bytes32, state: State) {
-        self.state_by_slot.insert(state.slot.0.0, root);
-        self.states.insert(root, state);
+        let slot = state.slot.0.0;
+        let block_root = root;
+        let state_root = Bytes32::from(state.hash_tree_root());
+        self.state_by_slot.insert(slot, block_root);
+        self.state_root_to_block_root.insert(state_root, block_root);
+        self.states.insert(block_root, state);
     }
 
     fn get_block(&self, root: &Bytes32) -> Option<Block> {
@@ -202,6 +209,12 @@ impl Store for MemoryStore {
         // we clone here, inevitable right ?
         state.process_signed_block(&signed)?;
         let block = signed.message.block.clone();
+        let slot = block.slot.0.0;
+        let post_state = state.clone();
+        let state_root = Bytes32::from(post_state.hash_tree_root());
+        self.state_by_slot.insert(slot, root);
+        self.state_root_to_block_root.insert(state_root, root);
+        self.states.insert(root, post_state);
         self.block_by_slot.insert(block.slot.0.0, root);
         self.blocks.insert(root, block);
         self.signed_blocks.insert(root, signed);
@@ -274,5 +287,42 @@ impl Store for MemoryStore {
 
     fn set_justified(&mut self, root: Bytes32) {
         self.justified = Some(root);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MemoryStore, Store};
+    use crate::containers::state::{State, Validators};
+    use crate::slot::Slot;
+    use crate::types::bytes::Bytes32;
+    use crate::types::uint::Uint64;
+    use peam_ssz::ssz::HashTreeRoot;
+
+    fn root_from_u64(v: u64) -> Bytes32 {
+        let mut out = [0u8; 32];
+        out[0..8].copy_from_slice(&v.to_le_bytes());
+        Bytes32::from(out)
+    }
+
+    fn dummy_state(slot: u64) -> State {
+        let mut state =
+            State::generate_genesis(Uint64(0), Validators::new(vec![]).expect("validators"));
+        state.slot = Slot(Uint64(slot));
+        state
+    }
+
+    #[test]
+    fn memory_store_put_state_is_block_root_keyed_with_state_root_compatibility() {
+        let mut store = MemoryStore::new();
+        let block_root = root_from_u64(42);
+        let state = dummy_state(7);
+        let state_root = Bytes32::from(state.hash_tree_root());
+
+        store.put_state(block_root, state.clone());
+
+        assert_eq!(store.get_state(&block_root), Some(state.clone()));
+        assert_eq!(store.get_state(&state_root), Some(state.clone()));
+        assert_eq!(store.get_state_by_slot(7), Some(state));
     }
 }

--- a/src/storage/pending.rs
+++ b/src/storage/pending.rs
@@ -6,8 +6,7 @@
 //! - No heap growth during steady-state operation.
 //!
 //! The cache is addressed by `slot % capacity` and stores the original slot
-//! alongside `(block_root, state_root)` so wraparound collisions are detected
-//! safely.
+//! alongside `block_root` so wraparound collisions are detected safely.
 
 use crate::types::bytes::Bytes32;
 
@@ -21,8 +20,6 @@ pub(super) struct PendingEntry {
     pub(super) slot: u64,
     /// Block root stored for this slot.
     pub(super) block_root: Bytes32,
-    /// State root stored for this slot.
-    pub(super) state_root: Bytes32,
 }
 
 /// Fixed-capacity slot-indexed pending cache.
@@ -67,18 +64,13 @@ impl PendingSlotCache {
         &mut self,
         slot: u64,
         block_root: Bytes32,
-        state_root: Bytes32,
     ) -> Option<PendingEntry> {
         let idx = self.index(slot);
         let prev = self.entries[idx];
         if prev.is_none() {
             self.count += 1;
         }
-        self.entries[idx] = Some(PendingEntry {
-            slot,
-            block_root,
-            state_root,
-        });
+        self.entries[idx] = Some(PendingEntry { slot, block_root });
         prev
     }
 
@@ -124,15 +116,15 @@ impl PendingSlotCache {
             .collect()
     }
 
-    /// Retains only entries for which `keep(slot, block_root, state_root)` returns `true`.
+    /// Retains only entries for which `keep(slot, block_root)` returns `true`.
     #[allow(dead_code)]
     pub(super) fn retain<F>(&mut self, mut keep: F)
     where
-        F: FnMut(u64, Bytes32, Bytes32) -> bool,
+        F: FnMut(u64, Bytes32) -> bool,
     {
         for entry in self.entries.iter_mut() {
             if let Some(value) = *entry {
-                if !keep(value.slot, value.block_root, value.state_root) {
+                if !keep(value.slot, value.block_root) {
                     *entry = None;
                     self.count -= 1;
                 }
@@ -163,16 +155,6 @@ impl PendingSlotCache {
         for entry in self.entries.iter().flatten() {
             block_roots.insert(entry.block_root);
             state_block_roots.insert(entry.block_root);
-        }
-    }
-
-    /// Extends a retention set with the state roots of all buffered pending entries.
-    pub(super) fn extend_referenced_state_roots(
-        &self,
-        state_roots: &mut rapidhash::RapidHashSet<Bytes32>,
-    ) {
-        for entry in self.entries.iter().flatten() {
-            state_roots.insert(entry.state_root);
         }
     }
 }

--- a/src/storage/prune.rs
+++ b/src/storage/prune.rs
@@ -1,6 +1,6 @@
 use super::*;
 use rapidhash::RapidHashSet;
-use tracing::{info, warn};
+use tracing::info;
 
 /// Statistics returned by [`FileStore::prune`].
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -58,24 +58,6 @@ impl FileStore {
             false
         });
 
-        let mut live_state_roots = RapidHashSet::<Bytes32>::default();
-        live_state_roots.extend(self.state_by_slot.values().copied());
-        self.pending_blocks
-            .extend_referenced_state_roots(&mut live_state_roots);
-        let missing_state_root_mappings = live_state_roots
-            .iter()
-            .filter(|state_root| !self.state_root_to_block_root.contains_key(*state_root))
-            .count();
-        if missing_state_root_mappings == 0 {
-            self.state_root_to_block_root
-                .retain(|state_root, _| live_state_roots.contains(state_root));
-        } else {
-            warn!(
-                missing_state_root_mappings,
-                "state-root mapping is incomplete; skipping state-root index rewrite for this prune pass to preserve existing lookups"
-            );
-        }
-
         // Canonical block index prune.
         self.block_by_slot.retain(|slot, root| {
             if *slot >= prune_before {
@@ -89,35 +71,18 @@ impl FileStore {
             false
         });
 
+        self.state_root_to_block_root = self.rebuild_live_state_root_index();
         self.index_dirty = true;
-        self.flush_canonical_with_state_root_index(missing_state_root_mappings == 0)?;
+        self.flush_canonical_with_state_root_index(true)?;
 
         let mut keep_state_block_roots = RapidHashSet::<Bytes32>::default();
-        for state_root in self.state_by_slot.values().copied() {
-            if let Some(block_root) = self.state_root_to_block_root.get(&state_root).copied() {
-                keep_state_block_roots.insert(block_root);
-            } else {
-                // Standalone `put_state` callers key state blobs directly by the
-                // provided root, so keep that root too. If the missing mapping
-                // belongs to migrated/imported state, we treat prune
-                // conservatively below and retain all state blobs for this pass.
-                keep_state_block_roots.insert(state_root);
-            }
-        }
+        keep_state_block_roots.extend(self.state_by_slot.values().copied());
         let mut keep_block_roots = RapidHashSet::<Bytes32>::default();
         keep_block_roots.extend(self.block_by_slot.values().copied());
         keep_block_roots.extend(pinned.iter().flatten().copied());
         keep_state_block_roots.extend(pinned.iter().flatten().copied());
         self.pending_blocks
             .extend_referenced_roots(&mut keep_block_roots, &mut keep_state_block_roots);
-
-        if missing_state_root_mappings > 0 {
-            warn!(
-                missing_state_root_mappings,
-                "state-root mapping is incomplete; skipping state-blob garbage collection for this prune pass to avoid deleting retained state"
-            );
-            keep_state_block_roots.extend(self.canonical_db.load_state_blob_roots()?);
-        }
 
         let gc = self
             .canonical_db

--- a/tests/prune_blob_gc.rs
+++ b/tests/prune_blob_gc.rs
@@ -85,3 +85,23 @@ fn prune_removes_unreferenced_state_and_block_blobs() {
 
     let _ = std::fs::remove_dir_all(dir);
 }
+
+#[test]
+fn pending_state_lookup_preserves_standalone_put_state_behavior() {
+    let dir = temp_store_dir("pending_standalone_state");
+    let mut store = FileStore::open(&dir).expect("open store");
+
+    let state_root = root_from_u64(10_001);
+    let block_root = root_from_u64(20_001);
+    let slot = 1;
+
+    store.put_state(state_root, dummy_state(slot));
+    store.put_block(block_root, dummy_block(slot));
+
+    let state = store
+        .get_state_by_slot(slot)
+        .expect("pending by-slot state should remain readable");
+    assert_eq!(state.slot.0.0, slot);
+
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/tests/prune_blob_gc.rs
+++ b/tests/prune_blob_gc.rs
@@ -52,8 +52,9 @@ fn prune_removes_unreferenced_state_and_block_blobs() {
     let mut store = FileStore::open(&dir).expect("open store");
 
     for slot in 0..rows {
-        store.put_state(root_from_u64(slot + 10_000), dummy_state(slot));
-        store.put_block(root_from_u64(slot + 20_000), dummy_block(slot));
+        let block_root = root_from_u64(slot + 20_000);
+        store.put_state(block_root, dummy_state(slot));
+        store.put_block(block_root, dummy_block(slot));
     }
 
     let report = store
@@ -67,16 +68,12 @@ fn prune_removes_unreferenced_state_and_block_blobs() {
     assert_eq!(report.removed_signed_blocks, 0);
 
     // Old blobs should be gone from root lookup.
-    assert!(store.get_state(&root_from_u64(10_000)).is_none());
     assert!(store.get_block(&root_from_u64(20_000)).is_none());
+    assert!(store.get_state(&root_from_u64(20_000)).is_none());
 
     // Recent roots should still be available.
     let newest_slot = rows - 1;
-    assert!(
-        store
-            .get_state(&root_from_u64(newest_slot + 10_000))
-            .is_some()
-    );
+    assert!(store.get_state(&root_from_u64(newest_slot + 20_000)).is_some());
     assert!(
         store
             .get_block(&root_from_u64(newest_slot + 20_000))
@@ -87,20 +84,19 @@ fn prune_removes_unreferenced_state_and_block_blobs() {
 }
 
 #[test]
-fn pending_state_lookup_preserves_standalone_put_state_behavior() {
-    let dir = temp_store_dir("pending_standalone_state");
+fn pending_state_lookup_uses_block_root_contract() {
+    let dir = temp_store_dir("pending_block_root_state");
     let mut store = FileStore::open(&dir).expect("open store");
 
-    let state_root = root_from_u64(10_001);
     let block_root = root_from_u64(20_001);
     let slot = 1;
 
-    store.put_state(state_root, dummy_state(slot));
+    store.put_state(block_root, dummy_state(slot));
     store.put_block(block_root, dummy_block(slot));
 
     let state = store
         .get_state_by_slot(slot)
-        .expect("pending by-slot state should remain readable");
+        .expect("pending by-slot state should be block-root keyed");
     assert_eq!(state.slot.0.0, slot);
 
     let _ = std::fs::remove_dir_all(dir);

--- a/tests/prune_perf_regression.rs
+++ b/tests/prune_perf_regression.rs
@@ -60,8 +60,9 @@ fn measure_prune_ms(rows: u64) -> f64 {
         let dir = temp_store_dir("prune_regression");
         let mut store = FileStore::open(&dir).expect("open store");
         for slot in 0..rows {
-            store.put_state(root_from_u64(slot + 10_000), dummy_state(slot));
-            store.put_block(root_from_u64(slot + 20_000), dummy_block(slot));
+            let block_root = root_from_u64(slot + 20_000);
+            store.put_state(block_root, dummy_state(slot));
+            store.put_block(block_root, dummy_block(slot));
         }
 
         let start = Instant::now();


### PR DESCRIPTION
fix the state root storage bug state root can't be used to keep canonical data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched slot-based indexing to use block roots first, renamed storage index semantics, simplified pending-slot handling, and unified live state-root index rebuild/prune behavior.

* **Bug Fixes**
  * Made state selection during block import, gossip, and backfill more consistent to reduce mismatches during sync.

* **Chores**
  * Bumped storage schema version to 3.

* **Tests**
  * Updated tests and added a test validating block-root–first state lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->