### PR TITLE
Feat: Fix attestation data fork-choice consistency

### DIFF
--- a/src/containers/state.rs
+++ b/src/containers/state.rs
@@ -32,6 +32,7 @@ use crate::containers::config::Config;
 use crate::containers::state_metrics::{NoopTransitionMetricsSink, TransitionMetricsSink};
 use crate::containers::validator::Validator;
 use crate::crypto::pq;
+use crate::logfmt::{short_opt_root_or_dash, short_root, short_slot_root};
 use crate::metrics::MetricsRegistry;
 use crate::slot::{self, Slot};
 use crate::ssz::hash::merkleize;
@@ -419,28 +420,29 @@ impl State {
         if computed_root != block.state_root {
             warn!(
                 block_slot = block.slot.0.0,
-                block_parent = ?block.parent_root,
-                block_state_root = ?block.state_root,
-                computed_state_root = ?computed_root,
+                block_parent = %short_root(&block.parent_root),
+                block_state_root = %short_root(&block.state_root),
+                computed_state_root = %short_root(&computed_root),
                 pre_slot,
                 pre_header_slot,
-                pre_header_root = ?pre_header_root,
+                pre_header_root = %short_root(&pre_header_root),
                 pre_justified_slot = pre_justified.slot.0.0,
-                pre_justified_root = ?pre_justified.root,
+                pre_justified_root = %short_root(&pre_justified.root),
                 pre_finalized_slot = pre_finalized.slot.0.0,
-                pre_finalized_root = ?pre_finalized.root,
-                post_slots_root = ?post_slots_root,
-                post_header_root = ?post_header_root,
-                post_attestations_root = ?post_attestations_root,
+                pre_finalized_root = %short_root(&pre_finalized.root),
+                post_slots_root = %short_opt_root_or_dash(post_slots_root),
+                post_header_root = %short_opt_root_or_dash(post_header_root),
+                post_attestations_root = %short_opt_root_or_dash(post_attestations_root),
                 post_slot = self.slot.0.0,
                 post_header_slot = self.latest_block_header.slot.0.0,
-                post_header_root = ?Bytes32::from(self.latest_block_header.hash_tree_root()),
+                post_header_root_live =
+                    %short_root(&Bytes32::from(self.latest_block_header.hash_tree_root())),
                 post_justified_slot = self.latest_justified.slot.0.0,
-                post_justified_root = ?self.latest_justified.root,
+                post_justified_root = %short_root(&self.latest_justified.root),
                 post_finalized_slot = self.latest_finalized.slot.0.0,
-                post_finalized_root = ?self.latest_finalized.root,
+                post_finalized_root = %short_root(&self.latest_finalized.root),
                 body_attestations = att_count,
-                "state transition state-root mismatch trace"
+                "state-root mismatch"
             );
             return Err("block state root does not match computed state root".to_string());
         } else {
@@ -451,13 +453,14 @@ impl State {
             || self.latest_finalized.slot > pre_finalized.slot
         {
             info!(
-                block_slot = block.slot.0.0,
-                block_root = ?Bytes32::from(block.hash_tree_root()),
+                block = %short_slot_root(block.slot.0.0, &Bytes32::from(block.hash_tree_root())),
                 pre_justified_slot = pre_justified.slot.0.0,
                 post_justified_slot = self.latest_justified.slot.0.0,
                 pre_finalized_slot = pre_finalized.slot.0.0,
                 post_finalized_slot = self.latest_finalized.slot.0.0,
-                "consensus checkpoints advanced"
+                justified = %short_root(&self.latest_justified.root),
+                finalized = %short_root(&self.latest_finalized.root),
+                "checkpoints advanced"
             );
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod checkpoint_sync;
 pub mod containers;
 pub mod crypto;
 pub mod fork_choice;
+pub mod logfmt;
 pub mod metrics;
 pub mod networking;
 pub mod node;

--- a/src/logfmt.rs
+++ b/src/logfmt.rs
@@ -1,0 +1,64 @@
+use crate::containers::checkpoint::Checkpoint;
+use crate::types::bytes::Bytes32;
+
+#[inline]
+pub fn short_root(root: &Bytes32) -> String {
+    let bytes = root.as_array();
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}",
+        bytes[0], bytes[1], bytes[2], bytes[3]
+    )
+}
+
+#[inline]
+pub fn short_opt_root(root: Option<Bytes32>) -> Option<String> {
+    root.map(|root| short_root(&root))
+}
+
+#[inline]
+pub fn short_opt_root_or_dash(root: Option<Bytes32>) -> String {
+    short_opt_root(root).unwrap_or_else(|| "-".to_string())
+}
+
+#[inline]
+pub fn short_checkpoint(checkpoint: &Checkpoint) -> String {
+    format!("{}:{}", checkpoint.slot.0.0, short_root(&checkpoint.root))
+}
+
+#[inline]
+pub fn short_slot_root(slot: u64, root: &Bytes32) -> String {
+    format!("{slot}:{}", short_root(root))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        short_checkpoint, short_opt_root, short_opt_root_or_dash, short_root, short_slot_root,
+    };
+    use crate::containers::checkpoint::Checkpoint;
+    use crate::slot::Slot;
+    use crate::types::bytes::Bytes32;
+    use crate::types::uint::Uint64;
+
+    fn root(byte: u8) -> Bytes32 {
+        Bytes32::from([byte; 32])
+    }
+
+    #[test]
+    fn formats_roots_compactly() {
+        assert_eq!(short_root(&root(0xab)), "abababab");
+        assert_eq!(short_opt_root(Some(root(0xcd))).as_deref(), Some("cdcdcdcd"));
+        assert_eq!(short_opt_root(None), None);
+        assert_eq!(short_opt_root_or_dash(None), "-");
+    }
+
+    #[test]
+    fn formats_checkpoint_and_slot_root_compactly() {
+        let checkpoint = Checkpoint {
+            slot: Slot(Uint64(42)),
+            root: root(0x12),
+        };
+        assert_eq!(short_checkpoint(&checkpoint), "42:12121212");
+        assert_eq!(short_slot_root(7, &root(0xef)), "7:efefefef");
+    }
+}

--- a/src/networking/gossipsub/validate.rs
+++ b/src/networking/gossipsub/validate.rs
@@ -17,6 +17,7 @@ use crate::containers::attestation::{
 };
 use crate::containers::block::SignedBlockWithAttestation;
 use crate::networking::gossipsub::context::GossipContext;
+use crate::logfmt::short_checkpoint;
 use crate::networking::gossipsub::lean::message::LeanGossipsubMessage;
 use crate::types::bitlist::BitList;
 
@@ -219,16 +220,13 @@ fn validate_attestation_data_with_context(
     if !knows_head || !knows_source || !knows_target {
         tracing::info!(
             attestation_slot = ?msg.slot,
-            head_slot = ?msg.head.slot,
-            source_slot = ?msg.source.slot,
-            target_slot = ?msg.target.slot,
-            head_root = ?msg.head.root,
-            source_root = ?msg.source.root,
-            target_root = ?msg.target.root,
+            head = %short_checkpoint(&msg.head),
+            source = %short_checkpoint(&msg.source),
+            target = %short_checkpoint(&msg.target),
             knows_head,
             knows_source,
             knows_target,
-            "peam attestation ignored due to unknown roots"
+            "attestation ignored: unknown roots"
         );
         return ValidationResult::Ignore(UNKNOWN_CHAIN_ROOTS_IGNORE_REASON.to_string());
     }

--- a/src/node/gossip.rs
+++ b/src/node/gossip.rs
@@ -10,6 +10,7 @@ use crate::containers::attestation::{Attestation, SignedAttestation, VALIDATOR_R
 use crate::containers::block::SignedBlockWithAttestation;
 use crate::containers::state::State;
 use crate::fork_choice::ForkChoiceStore;
+use crate::logfmt::{short_checkpoint, short_root, short_slot_root};
 use crate::metrics::MetricsRegistry;
 use crate::networking::GossipContext;
 use crate::networking::gossipsub::lean::message::LeanGossipsubMessage;
@@ -307,18 +308,25 @@ pub fn handle_gossip_event<S: Store + Send + Sync + 'static>(
                                 *fc = Some(new_fc);
                             }
                             Err(err) => {
-                                warn!("fork choice init failed root={root:?} err={err}");
+                                warn!(
+                                    block = %short_slot_root(signed.message.block.slot.0.0, &root),
+                                    err = %err,
+                                    "gossip block fork-choice init failed"
+                                );
                             }
                         }
                     } else if let Some(fc) = fc.as_mut() {
                         if let Err(err) = fc.on_block(signed.clone(), fc_state) {
-                            warn!("fork choice on_block failed root={root:?} err={err}");
+                            warn!(
+                                block = %short_slot_root(signed.message.block.slot.0.0, &root),
+                                err = %err,
+                                "gossip block fork-choice update failed"
+                            );
                         }
                     }
                     info!(
-                        root = ?root,
-                        slot = signed.message.block.slot.0.0,
-                        parent_root = ?signed.message.block.parent_root,
+                        block = %short_slot_root(signed.message.block.slot.0.0, &root),
+                        parent = %short_root(&signed.message.block.parent_root),
                         "gossip block imported"
                     );
                     enqueue_proposer_attestation_from_signed_block(pending_attestations, &signed);
@@ -327,7 +335,12 @@ pub fn handle_gossip_event<S: Store + Send + Sync + 'static>(
                         .observe_duration(block_start);
                 }
                 Err(err) => {
-                    warn!("block import failed root={root:?} err={err}");
+                    warn!(
+                        block = %short_slot_root(signed.message.block.slot.0.0, &root),
+                        parent = %short_root(&signed.message.block.parent_root),
+                        err = %err,
+                        "gossip block import failed"
+                    );
                 }
             }
         }
@@ -359,12 +372,11 @@ pub fn handle_gossip_event<S: Store + Send + Sync + 'static>(
             }
             info!(
                 slot = att.data.slot.0.0,
-                target_slot = att.data.target.slot.0.0,
-                target_root = ?att.data.target.root,
-                source_slot = att.data.source.slot.0.0,
-                source_root = ?att.data.source.root,
+                head = %short_checkpoint(&att.data.head),
+                target = %short_checkpoint(&att.data.target),
+                source = %short_checkpoint(&att.data.source),
                 participants_len_bits = att.proof.participants.len,
-                "gossip aggregated attestation received"
+                "gossip attestation aggregate received"
             );
             let pending = Attestation {
                 aggregation_bits: att.proof.participants.clone(),

--- a/src/node/tasks.rs
+++ b/src/node/tasks.rs
@@ -22,6 +22,7 @@ use crate::containers::gossip::{GossipAttestation, GossipBlock};
 use crate::containers::state::State;
 use crate::containers::validator::ValidatorIndex;
 use crate::fork_choice::ForkChoiceStore;
+use crate::logfmt::{short_checkpoint, short_root, short_slot_root};
 use crate::metrics::MetricsRegistry;
 use crate::networking::P2pCommand;
 use crate::slot::{
@@ -328,11 +329,10 @@ pub(super) fn spawn_signed_attestation_task(
             info!(
                 slot,
                 validator_id = local_validator_index,
-                target_slot = signed.message.target.slot.0.0,
-                target_root = ?signed.message.target.root,
-                source_slot = signed.message.source.slot.0.0,
-                source_root = ?signed.message.source.root,
-                "published attestation"
+                head = %short_checkpoint(&signed.message.head),
+                target = %short_checkpoint(&signed.message.target),
+                source = %short_checkpoint(&signed.message.source),
+                "attestation published"
             );
             if is_aggregator {
                 pending_individual_attestations
@@ -506,12 +506,11 @@ pub(super) fn spawn_attestation_aggregation_task(
                     .await;
                 info!(
                     slot = attestation.data.slot.0.0,
-                    target_slot = attestation.data.target.slot.0.0,
-                    target_root = ?attestation.data.target.root,
-                    source_slot = attestation.data.source.slot.0.0,
-                    source_root = ?attestation.data.source.root,
+                    head = %short_checkpoint(&attestation.data.head),
+                    target = %short_checkpoint(&attestation.data.target),
+                    source = %short_checkpoint(&attestation.data.source),
                     participants_len_bits = attestation.aggregation_bits.len,
-                    "published aggregated attestation"
+                    "attestation aggregate published"
                 );
             }
         }
@@ -713,7 +712,7 @@ fn build_block_attestation_payload(
             slot,
             finalized_slot,
             stale_dropped,
-            "dropping stale pending block attestations before proposal"
+            "proposal dropped stale pending attestations"
         );
     }
 
@@ -1092,7 +1091,8 @@ pub(super) fn spawn_block_production_task(
                                 && let Err(err) = fc.on_block(signed.clone(), state_guard.clone())
                             {
                                 warn!(
-                                    "fork_choice on_block failed for locally produced block: {err}"
+                                    err = %err,
+                                    "local block fork-choice update failed"
                                 );
                             }
                             Ok(())
@@ -1117,10 +1117,28 @@ pub(super) fn spawn_block_production_task(
                             if attempt == 0 {
                                 continue;
                             }
-                            warn!("failed to import locally produced block after retry: {err}");
+                            warn!(
+                                slot = signed.message.block.slot.0.0,
+                                block = %short_slot_root(
+                                    signed.message.block.slot.0.0,
+                                    &Bytes32::from(signed.message.block.hash_tree_root())
+                                ),
+                                parent = %short_root(&signed.message.block.parent_root),
+                                err = %err,
+                                "local block import failed after retry"
+                            );
                             break;
                         }
-                        warn!("failed to import locally produced block: {err}");
+                        warn!(
+                            slot = signed.message.block.slot.0.0,
+                            block = %short_slot_root(
+                                signed.message.block.slot.0.0,
+                                &Bytes32::from(signed.message.block.hash_tree_root())
+                            ),
+                            parent = %short_root(&signed.message.block.parent_root),
+                            err = %err,
+                            "local block import failed"
+                        );
                         break;
                     }
                 }
@@ -1132,11 +1150,10 @@ pub(super) fn spawn_block_production_task(
 
             let root = Bytes32::from(signed.message.block.hash_tree_root());
             info!(
-                root = ?root,
-                slot = signed.message.block.slot.0.0,
-                parent_root = ?signed.message.block.parent_root,
+                block = %short_slot_root(signed.message.block.slot.0.0, &root),
+                parent = %short_root(&signed.message.block.parent_root),
                 attestation_count = signed.message.block.body.attestations.len(),
-                "local block produced and imported"
+                "local block imported"
             );
 
             let payload = GossipBlock { block: signed }.encode_ssz();

--- a/src/node/tasks.rs
+++ b/src/node/tasks.rs
@@ -36,7 +36,7 @@ use crate::types::bytes::{ByteList, Bytes32, Bytes52};
 use crate::types::collections::SszList;
 use crate::types::uint::Uint64;
 
-use super::head::{aggregate_attestations, proposal_head_from_pending};
+use super::head::aggregate_attestations;
 
 #[derive(Clone)]
 pub struct PendingBlockAttestation {
@@ -275,59 +275,13 @@ pub(super) fn spawn_signed_attestation_task(
             if interval != ATTESTATION_INTERVAL_INDEX {
                 continue;
             }
-            let mut slot = slot_index_from_unix_millis(genesis_time_secs, now_millis);
-
-            let att_data = {
-                let guard = state.read().expect("state lock");
-                let source = guard.latest_justified;
-                let finalized_slot = guard.latest_finalized.slot;
-                let pending_head_root =
-                    proposal_head_from_pending(&fork_choice, &pending_attestations);
-
-                let (mut head, target) = {
-                    let fc_guard = fork_choice.read().expect("fork choice lock");
-                    if let Some(fc) = fc_guard.as_ref() {
-                        let head_root = pending_head_root.unwrap_or_else(|| fc.head());
-                        let head = fc.checkpoint_for_root(head_root).unwrap_or(Checkpoint {
-                            root: head_root,
-                            slot: Slot(Uint64(fc.head_slot())),
-                        });
-                        let target = fc.attestation_target(finalized_slot).unwrap_or(source);
-                        (head, target)
-                    } else {
-                        (
-                            Checkpoint {
-                                root: Bytes32::from(guard.latest_block_header.hash_tree_root()),
-                                slot: guard.slot,
-                            },
-                            source,
-                        )
-                    }
-                };
-
-                // Keep attestation fields internally coherent and avoid producing
-                // degenerate target==source attestations rejected by other clients.
-                if head.slot < target.slot {
-                    head = target;
-                }
-                if target.slot <= source.slot
-                    || !matches!(
-                        crate::slot::is_justifiable_after(target.slot, finalized_slot),
-                        Ok(true)
-                    )
-                {
-                    continue;
-                }
-                if slot < head.slot.0.0 {
-                    slot = head.slot.0.0;
-                }
-                AttestationData {
-                    slot: Slot(Uint64(slot)),
-                    head,
-                    target,
-                    source,
-                }
+            let slot = slot_index_from_unix_millis(genesis_time_secs, now_millis);
+            let Some(att_data) =
+                load_attestation_data(&state, &fork_choice, &pending_attestations, slot)
+            else {
+                continue;
             };
+            let slot = att_data.slot.0.0;
             if last_signed_slot == Some(slot) {
                 continue;
             }
@@ -399,6 +353,78 @@ pub(super) fn spawn_signed_attestation_task(
             last_signed_slot = Some(slot);
         }
     }))
+}
+
+#[inline]
+fn load_attestation_data(
+    state: &Arc<RwLock<State>>,
+    fork_choice: &Arc<RwLock<Option<ForkChoiceStore>>>,
+    pending_attestations: &Arc<RwLock<Vec<Attestation>>>,
+    slot: u64,
+) -> Option<AttestationData> {
+    let pending_snapshot = pending_attestations
+        .read()
+        .expect("pending attestations lock")
+        .clone();
+    let aggregated_pending = aggregate_attestations(pending_snapshot);
+
+    let mut fc_guard = fork_choice.write().expect("fork choice lock");
+    if let Some(fc) = fc_guard.as_mut() {
+        let head_root = fc.get_proposal_head_with_pending(aggregated_pending.iter());
+        let source = fc.latest_justified();
+        let finalized_slot = fc.latest_finalized().slot;
+        let mut head = fc.checkpoint_for_root(head_root).unwrap_or(Checkpoint {
+            root: head_root,
+            slot: Slot(Uint64(fc.head_slot())),
+        });
+        let target = fc.attestation_target(finalized_slot).unwrap_or(source);
+
+        if head.slot < target.slot {
+            head = target;
+        }
+        if target.slot <= source.slot
+            || !matches!(
+                crate::slot::is_justifiable_after(target.slot, finalized_slot),
+                Ok(true)
+            )
+        {
+            return None;
+        }
+
+        return Some(AttestationData {
+            slot: Slot(Uint64(slot.max(head.slot.0.0))),
+            head,
+            target,
+            source,
+        });
+    }
+    drop(fc_guard);
+
+    let guard = state.read().expect("state lock");
+    let source = guard.latest_justified;
+    let finalized_slot = guard.latest_finalized.slot;
+    let mut head = Checkpoint {
+        root: Bytes32::from(guard.latest_block_header.hash_tree_root()),
+        slot: guard.slot,
+    };
+    let target = source;
+    if head.slot < target.slot {
+        head = target;
+    }
+    if target.slot <= source.slot
+        || !matches!(
+            crate::slot::is_justifiable_after(target.slot, finalized_slot),
+            Ok(true)
+        )
+    {
+        return None;
+    }
+    Some(AttestationData {
+        slot: Slot(Uint64(slot.max(head.slot.0.0))),
+        head,
+        target,
+        source,
+    })
 }
 
 #[inline]
@@ -645,6 +671,7 @@ fn aggregate_signed_attestations(
 #[inline]
 fn build_block_attestation_payload(
     slot: u64,
+    finalized_slot: u64,
     pending_block_attestations: &Arc<RwLock<Vec<PendingBlockAttestation>>>,
     devnet_validator_keys: &DevnetValidatorKeyCache,
     metrics: &MetricsRegistry,
@@ -662,8 +689,13 @@ fn build_block_attestation_payload(
     let mut attestations = Vec::new();
     let mut proofs = Vec::new();
     let mut unaggregated = Vec::new();
+    let mut stale_dropped = 0usize;
 
     for entry in drained {
+        if entry.attestation.data.target.slot.0.0 < finalized_slot {
+            stale_dropped += 1;
+            continue;
+        }
         if let Some(proof) = entry.proof {
             let mut attestation = entry.attestation;
             if attestation.aggregation_bits != proof.participants {
@@ -674,6 +706,15 @@ fn build_block_attestation_payload(
         } else {
             unaggregated.push(entry.attestation);
         }
+    }
+
+    if stale_dropped > 0 {
+        warn!(
+            slot,
+            finalized_slot,
+            stale_dropped,
+            "dropping stale pending block attestations before proposal"
+        );
     }
 
     if attestations.len() >= ATTESTATIONS_LIMIT {
@@ -783,6 +824,7 @@ fn produce_block_with_signatures(
     };
     let (block_attestations, attestation_proofs) = build_block_attestation_payload(
         slot,
+        pre_state.latest_finalized.slot.0.0,
         pending_block_attestations,
         devnet_validator_keys,
         metrics,
@@ -1110,12 +1152,26 @@ pub(super) fn spawn_block_production_task(
 
 #[cfg(test)]
 mod tests {
-    use super::load_proposal_pre_state;
+    use super::{
+        PendingBlockAttestation, build_block_attestation_payload, load_attestation_data,
+        load_proposal_pre_state,
+    };
+    use crate::containers::attestation::{
+        AggregatedSignatureProof, Attestation, AttestationData, PROOF_MAX_BYTES,
+    };
+    use crate::containers::block::{
+        Block, BlockBody, BlockSignatures, BlockWithAttestation, SignedBlockWithAttestation,
+    };
     use crate::containers::checkpoint::Checkpoint;
+    use crate::containers::validator::ValidatorIndex;
+    use crate::fork_choice::ForkChoiceStore;
     use crate::containers::state::{State, Validators};
+    use crate::metrics::MetricsRegistry;
     use crate::slot::Slot;
     use crate::storage::{FileStore, Store};
-    use crate::types::bytes::Bytes32;
+    use crate::types::bitlist::BitList;
+    use crate::types::bytes::{ByteList, Bytes32, Bytes3112};
+    use crate::types::collections::SszList;
     use crate::types::uint::Uint64;
     use peam_ssz::ssz::HashTreeRoot;
     use std::path::PathBuf;
@@ -1140,6 +1196,102 @@ mod tests {
             State::generate_genesis(Uint64(0), Validators::new(vec![]).expect("validators"));
         state.slot = Slot(Uint64(slot));
         state
+    }
+
+    fn empty_signed_block(
+        slot: u64,
+        parent_root: Bytes32,
+        state_root: Bytes32,
+    ) -> SignedBlockWithAttestation {
+        SignedBlockWithAttestation {
+            message: BlockWithAttestation {
+                block: Block {
+                    slot: Slot(Uint64(slot)),
+                    proposer_index: ValidatorIndex(Uint64(0)),
+                    parent_root,
+                    state_root,
+                    body: BlockBody {
+                        attestations: SszList::new(Vec::new()).expect("empty attestations"),
+                    },
+                },
+                proposer_attestation: Attestation {
+                    aggregation_bits: BitList::new(vec![true]).expect("bitlist"),
+                    data: AttestationData {
+                        slot: Slot(Uint64(slot)),
+                        head: Checkpoint {
+                            slot: Slot(Uint64(slot)),
+                            root: parent_root,
+                        },
+                        target: Checkpoint {
+                            slot: Slot(Uint64(slot)),
+                            root: parent_root,
+                        },
+                        source: Checkpoint {
+                            slot: Slot(Uint64(slot)),
+                            root: parent_root,
+                        },
+                    },
+                },
+            },
+            signature: BlockSignatures {
+                attestation_signatures: SszList::new(Vec::new()).expect("empty proofs"),
+                proposer_signature: Bytes3112::zero(),
+            },
+        }
+    }
+
+    fn fork_choice_with_checkpoint_view(
+        head_slot: u64,
+        justified_slot: u64,
+        finalized_slot: u64,
+    ) -> ForkChoiceStore {
+        let mut anchor_state = dummy_state(head_slot);
+        let anchor_state_root = root_from_u64(9_999);
+        anchor_state.latest_block_header.slot = Slot(Uint64(head_slot));
+        anchor_state.latest_block_header.state_root = anchor_state_root;
+        anchor_state.latest_justified = Checkpoint {
+            slot: Slot(Uint64(justified_slot)),
+            root: root_from_u64(justified_slot),
+        };
+        anchor_state.latest_finalized = Checkpoint {
+            slot: Slot(Uint64(finalized_slot)),
+            root: root_from_u64(finalized_slot),
+        };
+
+        ForkChoiceStore::new(
+            empty_signed_block(head_slot, Bytes32::zero(), anchor_state_root),
+            anchor_state,
+        )
+        .expect("fork choice")
+    }
+
+    fn dummy_attestation(target_slot: u64) -> Attestation {
+        let bits = BitList::new(vec![true]).expect("bitlist");
+        Attestation {
+            aggregation_bits: bits,
+            data: AttestationData {
+                slot: Slot(Uint64(target_slot)),
+                head: Checkpoint {
+                    slot: Slot(Uint64(target_slot)),
+                    root: root_from_u64(target_slot + 1_000),
+                },
+                source: Checkpoint {
+                    slot: Slot(Uint64(target_slot.saturating_sub(1))),
+                    root: root_from_u64(target_slot + 2_000),
+                },
+                target: Checkpoint {
+                    slot: Slot(Uint64(target_slot)),
+                    root: root_from_u64(target_slot + 3_000),
+                },
+            },
+        }
+    }
+
+    fn dummy_proof(attestation: &Attestation) -> AggregatedSignatureProof {
+        AggregatedSignatureProof {
+            participants: attestation.aggregation_bits.clone(),
+            proof_data: ByteList::<PROOF_MAX_BYTES>::new(vec![1, 2, 3]).expect("proof bytes"),
+        }
     }
 
     #[test]
@@ -1202,5 +1354,66 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn proposal_payload_drops_attestations_behind_finalized_slot() {
+        let stale_attestation = dummy_attestation(3);
+        let current_attestation = dummy_attestation(8);
+        let pending = Arc::new(RwLock::new(vec![
+            PendingBlockAttestation {
+                attestation: stale_attestation.clone(),
+                proof: Some(dummy_proof(&stale_attestation)),
+            },
+            PendingBlockAttestation {
+                attestation: current_attestation.clone(),
+                proof: Some(dummy_proof(&current_attestation)),
+            },
+        ]));
+
+        let (attestations, proofs) = build_block_attestation_payload(
+            9,
+            5,
+            &pending,
+            &Arc::new(Vec::new()),
+            &MetricsRegistry::new(),
+        );
+
+        assert_eq!(attestations.len(), 1);
+        assert_eq!(proofs.len(), 1);
+        assert_eq!(attestations[0].data.target.slot, current_attestation.data.target.slot);
+        assert!(
+            pending.read().expect("pending lock").is_empty(),
+            "payload builder should still drain the pending queue"
+        );
+    }
+
+    #[test]
+    fn attestation_data_prefers_fork_choice_checkpoint_view_over_live_state() {
+        let live_state = {
+            let mut state = dummy_state(14);
+            state.latest_justified = Checkpoint {
+                slot: Slot(Uint64(5)),
+                root: root_from_u64(5),
+            };
+            state.latest_finalized = Checkpoint {
+                slot: Slot(Uint64(4)),
+                root: root_from_u64(4),
+            };
+            state
+        };
+
+        let att_data = load_attestation_data(
+            &Arc::new(RwLock::new(live_state)),
+            &Arc::new(RwLock::new(Some(fork_choice_with_checkpoint_view(14, 9, 5)))),
+            &Arc::new(RwLock::new(Vec::new())),
+            14,
+        )
+        .expect("attestation data");
+
+        assert_eq!(att_data.source.slot, Slot(Uint64(9)));
+        assert_eq!(att_data.head.slot, Slot(Uint64(14)));
+        assert_eq!(att_data.target.slot, Slot(Uint64(14)));
+        assert_eq!(att_data.slot, Slot(Uint64(14)));
     }
 }

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -46,6 +46,7 @@ use super::canonical_db::CanonicalDb;
 use super::pending::PendingSlotCache;
 use super::*;
 use crate::containers::checkpoint::Checkpoint;
+use crate::logfmt::{short_opt_root_or_dash, short_root, short_slot_root};
 use crate::ssz::{HashTreeRoot, SszEncode};
 
 /// A disk-backed [`Store`] with canonical+pending slot indexes as truth.
@@ -426,17 +427,16 @@ impl FileStore {
         let counter = PERSIST_LOGS.get_or_init(|| AtomicUsize::new(0));
         if counter.fetch_add(1, Ordering::Relaxed) < 64 {
             tracing::info!(
-                block_root = ?root,
-                block_slot = slot,
-                parent_root = ?block.parent_root,
-                state_root = ?state_root,
-                head_root = ?next_head,
-                justified_root = ?next_justified,
-                finalized_root = ?next_finalized,
+                block = %short_slot_root(slot, &root),
+                parent = %short_root(&block.parent_root),
+                state = %short_root(&state_root),
+                head = %short_opt_root_or_dash(next_head),
+                justified = %short_opt_root_or_dash(next_justified),
+                finalized = %short_opt_root_or_dash(next_finalized),
                 finalized_slot = next_finalized_slot.unwrap_or(0),
                 state_slot = persisted_state.slot.0.0,
                 latest_header_slot = persisted_state.latest_block_header.slot.0.0,
-                "persisted signed block bundle"
+                "signed block bundle persisted"
             );
         }
 


### PR DESCRIPTION
Fix attestation data fork-choice consistency and add regression tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filter out stale attestations during block payload construction; attestation derivation now prefers the fork-choice checkpoint view for correctness.

* **Style**
  * Switch to compact, short-form checkpoint/root logging across gossip, networking, state, storage and node flows for clearer logs.

* **Tests**
  * Added unit tests covering attestation filtering and block payload building behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->