### PR TITLE
Cap block attestation data entries at 16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,6 +3547,7 @@ dependencies = [
  "peam-ssz",
  "rand 0.9.2",
  "rapidhash 1.4.0",
+ "rayon",
  "redb",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ sha2 = "0.10"
 
 [dev-dependencies]
 criterion = "0.5"
+rayon = "1"
 serde_json = "1"
 ssz_types = { git = "https://github.com/sigp/ssz_types.git", rev = "5dc2d521ed31f8e38b0065a80bf98af55aac06f8" }
 ssz = { package = "ethereum_ssz", version = "0.10.1" }

--- a/benches/pq_signature_baseline.rs
+++ b/benches/pq_signature_baseline.rs
@@ -1,7 +1,32 @@
 use criterion::black_box;
 use criterion::{Criterion, criterion_group, criterion_main};
+use rayon::prelude::*;
 
 use peam::crypto::pq;
+
+fn sign_aggregate_parallel(
+    public_keys: &[peam::types::bytes::Bytes52],
+    secret_keys: &[&pq::LeanSigSecretKey],
+    epoch: u32,
+    message: &[u8; 32],
+) -> Result<Vec<u8>, String> {
+    if public_keys.is_empty() {
+        return Err("aggregate signature participants must be non-empty".to_string());
+    }
+    if public_keys.len() != secret_keys.len() {
+        return Err(format!(
+            "public key count ({}) does not match secret key count ({})",
+            public_keys.len(),
+            secret_keys.len()
+        ));
+    }
+
+    let signatures: Result<Vec<_>, _> = secret_keys
+        .par_iter()
+        .map(|secret_key| pq::sign_message(secret_key, epoch, message))
+        .collect();
+    pq::aggregate_signatures(public_keys, &signatures?, message, epoch)
+}
 
 fn bench_pq_signature_baseline(c: &mut Criterion) {
     let mut group = c.benchmark_group("pq_signature_baseline");
@@ -18,6 +43,8 @@ fn bench_pq_signature_baseline(c: &mut Criterion) {
     let sig0 = pq::sign_message(&sk0, 1, &message).expect("sig0");
 
     let agg2 = pq::sign_aggregate(&[pk0, pk1], &[&sk0, &sk1], 1, &message).expect("agg2");
+    let agg4 = pq::sign_aggregate(&[pk0, pk1, pk2, pk3], &[&sk0, &sk1, &sk2, &sk3], 1, &message)
+        .expect("agg4");
     let agg5 = pq::sign_aggregate(
         &[pk0, pk1, pk2, pk3, pk4],
         &[&sk0, &sk1, &sk2, &sk3, &sk4],
@@ -49,6 +76,44 @@ fn bench_pq_signature_baseline(c: &mut Criterion) {
                 1,
             )
             .expect("verify agg2");
+        })
+    });
+
+    group.bench_function("sign_aggregate_multisig_4_sequential", |b| {
+        b.iter(|| {
+            let proof = pq::sign_aggregate(
+                black_box(&[pk0, pk1, pk2, pk3]),
+                black_box(&[&sk0, &sk1, &sk2, &sk3]),
+                1,
+                black_box(&message),
+            )
+            .expect("aggregate sequential");
+            black_box(proof)
+        })
+    });
+
+    group.bench_function("sign_aggregate_multisig_4_outer_parallel", |b| {
+        b.iter(|| {
+            let proof = sign_aggregate_parallel(
+                black_box(&[pk0, pk1, pk2, pk3]),
+                black_box(&[&sk0, &sk1, &sk2, &sk3]),
+                1,
+                black_box(&message),
+            )
+            .expect("aggregate parallel");
+            black_box(proof)
+        })
+    });
+
+    group.bench_function("verify_aggregate_multisig_4", |b| {
+        b.iter(|| {
+            pq::verify_aggregate_signature(
+                black_box(&[pk0, pk1, pk2, pk3]),
+                black_box(&message),
+                black_box(&agg4),
+                1,
+            )
+            .expect("verify agg4");
         })
     });
 

--- a/benches/pq_signature_baseline.rs
+++ b/benches/pq_signature_baseline.rs
@@ -3,6 +3,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use rayon::prelude::*;
 
 use peam::crypto::pq;
+use peam::crypto::pq::DevnetValidatorKeyRole;
 
 fn sign_aggregate_parallel(
     public_keys: &[peam::types::bytes::Bytes52],
@@ -33,11 +34,21 @@ fn bench_pq_signature_baseline(c: &mut Criterion) {
     pq::setup_aggregate_prover();
     pq::setup_aggregate_verifier();
 
-    let (pk0, sk0) = pq::key_gen_for_devnet_validator(0).expect("key0");
-    let (pk1, sk1) = pq::key_gen_for_devnet_validator(1).expect("key1");
-    let (pk2, sk2) = pq::key_gen_for_devnet_validator(2).expect("key2");
-    let (pk3, sk3) = pq::key_gen_for_devnet_validator(3).expect("key3");
-    let (pk4, sk4) = pq::key_gen_for_devnet_validator(4).expect("key4");
+    let (pk0, sk0) =
+        pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
+            .expect("key0");
+    let (pk1, sk1) =
+        pq::key_gen_for_devnet_validator_with_role(1, DevnetValidatorKeyRole::Attestation)
+            .expect("key1");
+    let (pk2, sk2) =
+        pq::key_gen_for_devnet_validator_with_role(2, DevnetValidatorKeyRole::Attestation)
+            .expect("key2");
+    let (pk3, sk3) =
+        pq::key_gen_for_devnet_validator_with_role(3, DevnetValidatorKeyRole::Attestation)
+            .expect("key3");
+    let (pk4, sk4) =
+        pq::key_gen_for_devnet_validator_with_role(4, DevnetValidatorKeyRole::Attestation)
+            .expect("key4");
 
     let message = [0x42u8; 32];
     let sig0 = pq::sign_message(&sk0, 1, &message).expect("sig0");

--- a/src/app.rs
+++ b/src/app.rs
@@ -960,7 +960,7 @@ pub fn build_genesis_with_validator_count(
     if validator_count == 0 {
         return Err("validator_count must be > 0".to_string());
     }
-    let validators = build_devnet_validators(validator_count);
+    let validators = build_devnet_validators(validator_count)?;
     Ok(State::generate_genesis(config.genesis_time, validators))
 }
 
@@ -1042,7 +1042,7 @@ pub fn build_genesis_from_config_yaml_with_override(
 }
 
 #[inline]
-fn build_devnet_validators(validator_count: usize) -> Validators {
+fn build_devnet_validators(validator_count: usize) -> Result<Validators, String> {
     let mut validators = Vec::with_capacity(validator_count);
     for i in 0..validator_count {
         let (attestation_pubkey, _) =
@@ -1050,12 +1050,12 @@ fn build_devnet_validators(validator_count: usize) -> Validators {
                 i,
                 crate::crypto::pq::DevnetValidatorKeyRole::Attestation,
             )
-            .expect("derive devnet attestation key");
+            .map_err(|err| format!("failed to derive devnet attestation key {i}: {err}"))?;
         let (proposal_pubkey, _) = crate::crypto::pq::key_gen_for_devnet_validator_with_role(
             i,
             crate::crypto::pq::DevnetValidatorKeyRole::Proposal,
         )
-        .expect("derive devnet proposal key");
+        .map_err(|err| format!("failed to derive devnet proposal key {i}: {err}"))?;
         // SAFETY:
         // - capacity was pre-allocated to `validator_count`, so writing at `i` is in-bounds.
         // - `len` is only incremented after both fallible key derivations succeed, so the
@@ -1074,7 +1074,7 @@ fn build_devnet_validators(validator_count: usize) -> Validators {
             )
         };
     }
-    Validators::new(validators).expect("devnet validator set")
+    Validators::new(validators).map_err(|err| format!("failed to build devnet validator set: {err}"))
 }
 
 #[inline]

--- a/src/app.rs
+++ b/src/app.rs
@@ -968,12 +968,9 @@ pub fn build_genesis_with_validator_count(
 ///
 /// Parses `GENESIS_TIME` and `GENESIS_VALIDATORS` from the YAML config.
 ///
-/// `GENESIS_VALIDATORS` accepts either:
-/// - the devnet4 structured shape:
-///   - `attestation_pubkey`
-///   - `proposal_pubkey`
-/// - or the legacy single-pubkey string list, which is treated as
-///   attestation/proposal pubkey duplication for compatibility.
+/// `GENESIS_VALIDATORS` must use the devnet4 structured shape:
+/// - `attestation_pubkey`
+/// - `proposal_pubkey`
 ///
 /// This is the canonical genesis used by all clients.
 pub fn build_genesis_from_config_yaml(path: &Path) -> Result<State, String> {
@@ -1005,38 +1002,34 @@ pub fn build_genesis_from_config_yaml_with_override(
     }
     let mut validators = Vec::with_capacity(validators_yaml.len());
     for (i, entry) in validators_yaml.iter().enumerate() {
-        let (attestation_pubkey, proposal_pubkey) = if let Some(hex_str) = entry.as_str() {
-            let pubkey = parse_genesis_validator_pubkey(path, i, "pubkey", hex_str)?;
-            (pubkey, pubkey)
-        } else if let Some(map) = entry.as_mapping() {
-            let attestation = map
-                .get(serde_yaml::Value::from("attestation_pubkey"))
-                .and_then(|value| value.as_str())
-                .ok_or_else(|| {
-                    format!(
-                        "GENESIS_VALIDATORS[{i}] missing attestation_pubkey in {}",
-                        path.display()
-                    )
-                })?;
-            let proposal = map
-                .get(serde_yaml::Value::from("proposal_pubkey"))
-                .and_then(|value| value.as_str())
-                .ok_or_else(|| {
-                    format!(
-                        "GENESIS_VALIDATORS[{i}] missing proposal_pubkey in {}",
-                        path.display()
-                    )
-                })?;
-            (
-                parse_genesis_validator_pubkey(path, i, "attestation_pubkey", attestation)?,
-                parse_genesis_validator_pubkey(path, i, "proposal_pubkey", proposal)?,
-            )
-        } else {
+        let Some(map) = entry.as_mapping() else {
             return Err(format!(
-                "GENESIS_VALIDATORS[{i}] must be a string or mapping in {}",
+                "GENESIS_VALIDATORS[{i}] must be a mapping with attestation_pubkey/proposal_pubkey in {}",
                 path.display()
             ));
         };
+        let attestation = map
+            .get(serde_yaml::Value::from("attestation_pubkey"))
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| {
+                format!(
+                    "GENESIS_VALIDATORS[{i}] missing attestation_pubkey in {}",
+                    path.display()
+                )
+            })?;
+        let proposal = map
+            .get(serde_yaml::Value::from("proposal_pubkey"))
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| {
+                format!(
+                    "GENESIS_VALIDATORS[{i}] missing proposal_pubkey in {}",
+                    path.display()
+                )
+            })?;
+        let attestation_pubkey =
+            parse_genesis_validator_pubkey(path, i, "attestation_pubkey", attestation)?;
+        let proposal_pubkey =
+            parse_genesis_validator_pubkey(path, i, "proposal_pubkey", proposal)?;
         validators.push(Validator {
             attestation_pubkey,
             proposal_pubkey,

--- a/src/app.rs
+++ b/src/app.rs
@@ -966,8 +966,16 @@ pub fn build_genesis_with_validator_count(
 
 /// Builds a genesis state from a lean-spec `config.yaml` file.
 ///
-/// Parses `GENESIS_TIME` and `GENESIS_VALIDATORS` (hex-encoded 52-byte pubkeys)
-/// from the YAML config. This is the canonical genesis used by all clients.
+/// Parses `GENESIS_TIME` and `GENESIS_VALIDATORS` from the YAML config.
+///
+/// `GENESIS_VALIDATORS` accepts either:
+/// - the devnet4 structured shape:
+///   - `attestation_pubkey`
+///   - `proposal_pubkey`
+/// - or the legacy single-pubkey string list, which is treated as
+///   attestation/proposal pubkey duplication for compatibility.
+///
+/// This is the canonical genesis used by all clients.
 pub fn build_genesis_from_config_yaml(path: &Path) -> Result<State, String> {
     build_genesis_from_config_yaml_with_override(path, None)
 }
@@ -997,25 +1005,41 @@ pub fn build_genesis_from_config_yaml_with_override(
     }
     let mut validators = Vec::with_capacity(validators_yaml.len());
     for (i, entry) in validators_yaml.iter().enumerate() {
-        let hex_str = entry
-            .as_str()
-            .ok_or_else(|| format!("GENESIS_VALIDATORS[{i}] is not a string"))?;
-        let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
-        let pk_bytes: Vec<u8> = (0..hex_str.len())
-            .step_by(2)
-            .map(|j| {
-                u8::from_str_radix(&hex_str[j..j + 2], 16)
-                    .map_err(|err| format!("GENESIS_VALIDATORS[{i}] bad hex: {err}"))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        if pk_bytes.len() != 52 {
+        let (attestation_pubkey, proposal_pubkey) = if let Some(hex_str) = entry.as_str() {
+            let pubkey = parse_genesis_validator_pubkey(path, i, "pubkey", hex_str)?;
+            (pubkey, pubkey)
+        } else if let Some(map) = entry.as_mapping() {
+            let attestation = map
+                .get(serde_yaml::Value::from("attestation_pubkey"))
+                .and_then(|value| value.as_str())
+                .ok_or_else(|| {
+                    format!(
+                        "GENESIS_VALIDATORS[{i}] missing attestation_pubkey in {}",
+                        path.display()
+                    )
+                })?;
+            let proposal = map
+                .get(serde_yaml::Value::from("proposal_pubkey"))
+                .and_then(|value| value.as_str())
+                .ok_or_else(|| {
+                    format!(
+                        "GENESIS_VALIDATORS[{i}] missing proposal_pubkey in {}",
+                        path.display()
+                    )
+                })?;
+            (
+                parse_genesis_validator_pubkey(path, i, "attestation_pubkey", attestation)?,
+                parse_genesis_validator_pubkey(path, i, "proposal_pubkey", proposal)?,
+            )
+        } else {
             return Err(format!(
-                "GENESIS_VALIDATORS[{i}] expected 52 bytes, got {}",
-                pk_bytes.len()
+                "GENESIS_VALIDATORS[{i}] must be a string or mapping in {}",
+                path.display()
             ));
-        }
+        };
         validators.push(Validator {
-            pubkey: Bytes52::from_slice(&pk_bytes),
+            attestation_pubkey,
+            proposal_pubkey,
             index: ValidatorIndex(Uint64(i as u64)),
             balance: Uint64(0),
         });
@@ -1032,17 +1056,25 @@ fn build_devnet_validators(validator_count: usize) -> Validators {
     // - each slot in [0, validator_count) is written exactly once below.
     unsafe { validators.set_len(validator_count) };
     for i in 0..validator_count {
-        let mut pubkey = [0u8; 52];
-        // Deterministic placeholder key material for local devnet topology.
-        pubkey[0] = 0xD1;
-        pubkey[1] = i as u8;
+        let (attestation_pubkey, _) =
+            crate::crypto::pq::key_gen_for_devnet_validator_with_role(
+                i,
+                crate::crypto::pq::DevnetValidatorKeyRole::Attestation,
+            )
+            .expect("derive devnet attestation key");
+        let (proposal_pubkey, _) = crate::crypto::pq::key_gen_for_devnet_validator_with_role(
+            i,
+            crate::crypto::pq::DevnetValidatorKeyRole::Proposal,
+        )
+        .expect("derive devnet proposal key");
         // SAFETY: `i < validator_count`, so index is in-bounds of initialized len.
         unsafe {
             write_at(
                 &mut validators,
                 i,
                 Validator {
-                    pubkey: Bytes52::from(pubkey),
+                    attestation_pubkey,
+                    proposal_pubkey,
                     index: ValidatorIndex(Uint64(i as u64)),
                     balance: Uint64(0),
                 },
@@ -1050,4 +1082,30 @@ fn build_devnet_validators(validator_count: usize) -> Validators {
         };
     }
     Validators::new(validators).expect("devnet validator set")
+}
+
+#[inline]
+fn parse_genesis_validator_pubkey(
+    path: &Path,
+    index: usize,
+    field: &str,
+    hex_str: &str,
+) -> Result<Bytes52, String> {
+    let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    let pk_bytes: Vec<u8> = (0..hex_str.len())
+        .step_by(2)
+        .map(|j| {
+            u8::from_str_radix(&hex_str[j..j + 2], 16).map_err(|err| {
+                format!("GENESIS_VALIDATORS[{index}].{field} bad hex in {}: {err}", path.display())
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if pk_bytes.len() != 52 {
+        return Err(format!(
+            "GENESIS_VALIDATORS[{index}].{field} expected 52 bytes in {}, got {}",
+            path.display(),
+            pk_bytes.len()
+        ));
+    }
+    Ok(Bytes52::from_slice(&pk_bytes))
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1044,10 +1044,6 @@ pub fn build_genesis_from_config_yaml_with_override(
 #[inline]
 fn build_devnet_validators(validator_count: usize) -> Validators {
     let mut validators = Vec::with_capacity(validator_count);
-    // SAFETY:
-    // - capacity is pre-allocated to `validator_count`.
-    // - each slot in [0, validator_count) is written exactly once below.
-    unsafe { validators.set_len(validator_count) };
     for i in 0..validator_count {
         let (attestation_pubkey, _) =
             crate::crypto::pq::key_gen_for_devnet_validator_with_role(
@@ -1060,8 +1056,12 @@ fn build_devnet_validators(validator_count: usize) -> Validators {
             crate::crypto::pq::DevnetValidatorKeyRole::Proposal,
         )
         .expect("derive devnet proposal key");
-        // SAFETY: `i < validator_count`, so index is in-bounds of initialized len.
+        // SAFETY:
+        // - capacity was pre-allocated to `validator_count`, so writing at `i` is in-bounds.
+        // - `len` is only incremented after both fallible key derivations succeed, so the
+        //   vector never exposes uninitialized elements on panic.
         unsafe {
+            validators.set_len(i + 1);
             write_at(
                 &mut validators,
                 i,
@@ -1085,6 +1085,12 @@ fn parse_genesis_validator_pubkey(
     hex_str: &str,
 ) -> Result<Bytes52, String> {
     let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    if hex_str.len() % 2 != 0 {
+        return Err(format!(
+            "GENESIS_VALIDATORS[{index}].{field} must have even-length hex in {}",
+            path.display()
+        ));
+    }
     let pk_bytes: Vec<u8> = (0..hex_str.len())
         .step_by(2)
         .map(|j| {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1085,6 +1085,12 @@ fn parse_genesis_validator_pubkey(
     hex_str: &str,
 ) -> Result<Bytes52, String> {
     let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    if !hex_str.is_ascii() {
+        return Err(format!(
+            "GENESIS_VALIDATORS[{index}].{field} must be ASCII hex in {}",
+            path.display()
+        ));
+    }
     if hex_str.len() % 2 != 0 {
         return Err(format!(
             "GENESIS_VALIDATORS[{index}].{field} must have even-length hex in {}",

--- a/src/bin/devnet2_registry_gen.rs
+++ b/src/bin/devnet2_registry_gen.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use leansig::serialization::Serializable;
-use peam::crypto::pq::key_gen_for_devnet_validator;
+use peam::crypto::pq::{DevnetValidatorKeyRole, key_gen_for_devnet_validator_with_role};
 
 const DEFAULT_VALIDATORS: usize = 3;
 const DEFAULT_NODE_MAP: &str = "peam_0:0,peer1_0:1,peer2_0:2";
@@ -12,8 +12,10 @@ const DEFAULT_ATTESTATION_SUBNETS: u64 = 1;
 
 #[derive(Clone)]
 struct ValidatorMaterial {
-    pubkey_hex_no_prefix: String,
-    privkey_file: String,
+    attestation_pubkey_hex_no_prefix: String,
+    proposal_pubkey_hex_no_prefix: String,
+    attestation_privkey_file: String,
+    proposal_privkey_file: String,
 }
 
 fn print_usage() {
@@ -204,7 +206,6 @@ fn main() {
         std::process::exit(1);
     });
 
-    let mut pubkeys = Vec::with_capacity(validator_count);
     let mut validator_material = Vec::with_capacity(validator_count);
     let mut manifest_lines = Vec::with_capacity(validator_count * 3 + 8);
     manifest_lines.push("key_scheme: SIGTopLevelTargetSumLifetime32Dim64Base8".to_string());
@@ -217,38 +218,66 @@ fn main() {
     manifest_lines.push("validators:".to_string());
 
     for idx in 0..validator_count {
-        let (pubkey, secret_key) = key_gen_for_devnet_validator(idx).unwrap_or_else(|err| {
-            eprintln!("failed to derive validator {idx}: {err}");
+        let (attestation_pubkey, attestation_secret_key) =
+            key_gen_for_devnet_validator_with_role(idx, DevnetValidatorKeyRole::Attestation)
+                .unwrap_or_else(|err| {
+                    eprintln!("failed to derive attestation key for validator {idx}: {err}");
+                    std::process::exit(1);
+                });
+        let (proposal_pubkey, proposal_secret_key) =
+            key_gen_for_devnet_validator_with_role(idx, DevnetValidatorKeyRole::Proposal)
+                .unwrap_or_else(|err| {
+                    eprintln!("failed to derive proposal key for validator {idx}: {err}");
+                    std::process::exit(1);
+                });
+
+        let attestation_pubkey_hex = hex_encode(attestation_pubkey.as_ref());
+        let proposal_pubkey_hex = hex_encode(proposal_pubkey.as_ref());
+
+        let attestation_sk_bytes = attestation_secret_key.to_bytes();
+        let attestation_sk_filename = format!("validator_{idx}_attestation_sk.ssz");
+        let attestation_sk_path = hash_sig_dir.join(&attestation_sk_filename);
+        fs::write(&attestation_sk_path, &attestation_sk_bytes).unwrap_or_else(|err| {
+            eprintln!("failed writing {}: {err}", attestation_sk_path.display());
             std::process::exit(1);
         });
 
-        let pubkey_hex = hex_encode(pubkey.as_ref());
-        pubkeys.push(pubkey_hex.clone());
-
-        let sk_bytes = secret_key.to_bytes();
-        let sk_filename = format!("validator_{idx}_sk.ssz");
-        let sk_path = hash_sig_dir.join(&sk_filename);
-        fs::write(&sk_path, &sk_bytes).unwrap_or_else(|err| {
-            eprintln!("failed writing {}: {err}", sk_path.display());
+        let attestation_pk_bytes = attestation_pubkey.as_array();
+        let attestation_pk_filename = format!("validator_{idx}_attestation_pk.ssz");
+        let attestation_pk_path = hash_sig_dir.join(&attestation_pk_filename);
+        fs::write(&attestation_pk_path, attestation_pk_bytes).unwrap_or_else(|err| {
+            eprintln!("failed writing {}: {err}", attestation_pk_path.display());
             std::process::exit(1);
         });
 
-        let pk_bytes = pubkey.as_array();
-        let pk_filename = format!("validator_{idx}_pk.ssz");
-        let pk_path = hash_sig_dir.join(&pk_filename);
-        fs::write(&pk_path, pk_bytes).unwrap_or_else(|err| {
-            eprintln!("failed writing {}: {err}", pk_path.display());
+        let proposal_sk_bytes = proposal_secret_key.to_bytes();
+        let proposal_sk_filename = format!("validator_{idx}_proposal_sk.ssz");
+        let proposal_sk_path = hash_sig_dir.join(&proposal_sk_filename);
+        fs::write(&proposal_sk_path, &proposal_sk_bytes).unwrap_or_else(|err| {
+            eprintln!("failed writing {}: {err}", proposal_sk_path.display());
+            std::process::exit(1);
+        });
+
+        let proposal_pk_bytes = proposal_pubkey.as_array();
+        let proposal_pk_filename = format!("validator_{idx}_proposal_pk.ssz");
+        let proposal_pk_path = hash_sig_dir.join(&proposal_pk_filename);
+        fs::write(&proposal_pk_path, proposal_pk_bytes).unwrap_or_else(|err| {
+            eprintln!("failed writing {}: {err}", proposal_pk_path.display());
             std::process::exit(1);
         });
 
         validator_material.push(ValidatorMaterial {
-            pubkey_hex_no_prefix: pubkey_hex.trim_start_matches("0x").to_string(),
-            privkey_file: sk_filename.clone(),
+            attestation_pubkey_hex_no_prefix: attestation_pubkey_hex.trim_start_matches("0x").to_string(),
+            proposal_pubkey_hex_no_prefix: proposal_pubkey_hex.trim_start_matches("0x").to_string(),
+            attestation_privkey_file: attestation_sk_filename.clone(),
+            proposal_privkey_file: proposal_sk_filename.clone(),
         });
 
         manifest_lines.push(format!("- index: {idx}"));
-        manifest_lines.push(format!("  pubkey_hex: {pubkey_hex}"));
-        manifest_lines.push(format!("  privkey_file: {sk_filename}"));
+        manifest_lines.push(format!("  attestation_pubkey_hex: {attestation_pubkey_hex}"));
+        manifest_lines.push(format!("  proposal_pubkey_hex: {proposal_pubkey_hex}"));
+        manifest_lines.push(format!("  attestation_privkey_file: {attestation_sk_filename}"));
+        manifest_lines.push(format!("  proposal_privkey_file: {proposal_sk_filename}"));
     }
 
     let manifest_path = hash_sig_dir.join("validator-keys-manifest.yaml");
@@ -257,12 +286,19 @@ fn main() {
         std::process::exit(1);
     });
 
-    let mut config_lines = Vec::with_capacity(pubkeys.len() + 3);
+    let mut config_lines = Vec::with_capacity(validator_material.len() * 3 + 3);
     config_lines.push(format!("GENESIS_TIME: {genesis_time}"));
     config_lines.push(format!("NUM_VALIDATORS: {validator_count}"));
     config_lines.push("GENESIS_VALIDATORS:".to_string());
-    for pk in &pubkeys {
-        config_lines.push(format!("- {pk}"));
+    for material in &validator_material {
+        config_lines.push(format!(
+            "- attestation_pubkey: \"0x{}\"",
+            material.attestation_pubkey_hex_no_prefix
+        ));
+        config_lines.push(format!(
+            "  proposal_pubkey: \"0x{}\"",
+            material.proposal_pubkey_hex_no_prefix
+        ));
     }
     let config_path = out_dir.join("config.yaml");
     fs::write(&config_path, config_lines.join("\n") + "\n").unwrap_or_else(|err| {
@@ -296,8 +332,22 @@ fn main() {
                 std::process::exit(1);
             });
             annotated_lines.push(format!("  - index: {idx}"));
-            annotated_lines.push(format!("    pubkey_hex: {}", material.pubkey_hex_no_prefix));
-            annotated_lines.push(format!("    privkey_file: {}", material.privkey_file));
+            annotated_lines.push(format!(
+                "    attestation_pubkey_hex: {}",
+                material.attestation_pubkey_hex_no_prefix
+            ));
+            annotated_lines.push(format!(
+                "    proposal_pubkey_hex: {}",
+                material.proposal_pubkey_hex_no_prefix
+            ));
+            annotated_lines.push(format!(
+                "    attestation_privkey_file: {}",
+                material.attestation_privkey_file
+            ));
+            annotated_lines.push(format!(
+                "    proposal_privkey_file: {}",
+                material.proposal_privkey_file
+            ));
         }
     }
     let annotated_validators_path = out_dir.join("annotated_validators.yaml");

--- a/src/checkpoint_sync.rs
+++ b/src/checkpoint_sync.rs
@@ -78,7 +78,9 @@ pub fn verify_checkpoint_state(state: &State, expected_genesis: &State) -> Resul
             .validators
             .get(idx)
             .ok_or_else(|| format!("missing genesis validator {idx}"))?;
-        if validator.pubkey != expected.pubkey {
+        if validator.attestation_pubkey != expected.attestation_pubkey
+            || validator.proposal_pubkey != expected.proposal_pubkey
+        {
             return Err(format!(
                 "checkpoint validator pubkey mismatch at index {idx}"
             ));

--- a/src/checkpoint_sync.rs
+++ b/src/checkpoint_sync.rs
@@ -82,7 +82,7 @@ pub fn verify_checkpoint_state(state: &State, expected_genesis: &State) -> Resul
             || validator.proposal_pubkey != expected.proposal_pubkey
         {
             return Err(format!(
-                "checkpoint validator pubkey mismatch at index {idx}"
+                "checkpoint validator key mismatch at index {idx}"
             ));
         }
         if validator.index.0.0 != idx as u64 {

--- a/src/containers/attestation.rs
+++ b/src/containers/attestation.rs
@@ -43,7 +43,7 @@ pub const PROOF_MAX_BYTES: usize = 1_048_576;
 /// | 8 – 47     | `head`   |
 /// | 48 – 87    | `target` |
 /// | 88 – 127   | `source` |
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct AttestationData {
     /// Slot at which the attestation was created.
     pub slot: Slot,

--- a/src/containers/block.rs
+++ b/src/containers/block.rs
@@ -12,6 +12,8 @@ use crate::unsafe_vec::write_bytes_at;
 
 /// Maximum number of attestations that can appear in a single block body.
 pub const ATTESTATIONS_LIMIT: usize = 4_096;
+/// Maximum number of distinct attestation-data entries that can appear in a block body.
+pub const MAX_ATTESTATIONS_DATA: usize = 16;
 
 /// SSZ list of [`Attestation`]s included in a block body.
 pub type Attestations = SszList<Attestation, ATTESTATIONS_LIMIT>;
@@ -177,6 +179,7 @@ impl SignedBlockWithAttestation {
                 ));
             }
         }
+        validate_attestation_data_limit(&block.body.attestations)?;
         let proposer_attestation = &self.message.proposer_attestation;
         if proposer_attestation.data.slot != block.slot {
             return Err("proposer attestation slot does not match block slot".to_string());
@@ -188,6 +191,35 @@ impl SignedBlockWithAttestation {
         }
         Ok(())
     }
+}
+
+#[inline]
+pub fn validate_attestation_data_limit(attestations: &Attestations) -> Result<(), String> {
+    let mut distinct = Vec::with_capacity(MAX_ATTESTATIONS_DATA);
+    for attestation in attestations.iter() {
+        if !track_distinct_attestation_data(&mut distinct, &attestation.data) {
+            return Err(format!(
+                "block contains more than {} distinct attestation data entries",
+                MAX_ATTESTATIONS_DATA
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[inline]
+pub(crate) fn track_distinct_attestation_data(
+    distinct: &mut Vec<AttestationData>,
+    data: &AttestationData,
+) -> bool {
+    if distinct.iter().any(|existing| existing == data) {
+        return true;
+    }
+    if distinct.len() >= MAX_ATTESTATIONS_DATA {
+        return false;
+    }
+    distinct.push(data.clone());
+    true
 }
 
 /// Return the index of the single set bit in `bits`, or `None` if there are zero

--- a/src/containers/state.rs
+++ b/src/containers/state.rs
@@ -76,6 +76,13 @@ pub type JustifiedSlots = BitList<HISTORICAL_ROOTS_LIMIT>;
 /// attestations.
 pub type JustificationValidators = BitList<JUSTIFICATION_VALIDATORS_LIMIT>;
 
+#[inline]
+fn proposer_pubkey_for(validators: &[Validator], proposer_idx: usize) -> Option<crate::types::bytes::Bytes52> {
+    validators
+        .get(proposer_idx)
+        .map(|validator| validator.proposal_pubkey)
+}
+
 /// `HashTreeRoot(BlockBody { attestations: [] })` — the body root used in the genesis
 /// block header.
 ///
@@ -940,7 +947,7 @@ impl SignatureVerifier for PqSignatureVerifier {
                     let validator = validators
                         .get(idx)
                         .ok_or_else(|| "validator index out of range".to_string())?;
-                    public_keys.push(validator.pubkey);
+                    public_keys.push(validator.attestation_pubkey);
                     remaining &= remaining - 1;
                 }
             }
@@ -960,12 +967,11 @@ impl SignatureVerifier for PqSignatureVerifier {
 
         let proposer_attestation = &signed.message.proposer_attestation;
         let proposer_idx = block.proposer_index.0.0 as usize;
-        let proposer = validators
-            .get(proposer_idx)
+        let proposer_pubkey = proposer_pubkey_for(validators, proposer_idx)
             .ok_or_else(|| "proposer index out of range".to_string())?;
         let proposer_message = proposer_attestation.data.hash_tree_root();
         pq::verify_signature(
-            &proposer.pubkey,
+            &proposer_pubkey,
             proposer_attestation.data.slot.0.0 as u32,
             &proposer_message,
             &signed.signature.proposer_signature,

--- a/src/containers/state.rs
+++ b/src/containers/state.rs
@@ -365,6 +365,7 @@ impl State {
         if expected_root != Bytes32::from(body_root) {
             return Err("block body root does not match header".to_string());
         }
+        crate::containers::block::validate_attestation_data_limit(&body.attestations)?;
         self.process_attestations(&body.attestations)?;
         Ok(())
     }

--- a/src/containers/validator.rs
+++ b/src/containers/validator.rs
@@ -21,7 +21,8 @@ impl ValidatorIndex {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Validator {
-    pub pubkey: Bytes52,
+    pub attestation_pubkey: Bytes52,
+    pub proposal_pubkey: Bytes52,
     pub index: ValidatorIndex,
     pub balance: Uint64,
 }
@@ -70,22 +71,24 @@ impl SszFixedLen for ValidatorIndex {
 
 impl SszEncode for Validator {
     fn encode_ssz(&self) -> Vec<u8> {
-        // Lean interop consensus encoding uses only pubkey + index.
-        let mut out = Vec::with_capacity(52 + 8);
-        unsafe { out.set_len(52 + 8) };
-        unsafe { write_bytes_at(&mut out, 0, self.pubkey.as_ref()) };
-        unsafe { write_bytes_at(&mut out, 52, &self.index.0.0.to_le_bytes()) };
+        let mut out = Vec::with_capacity(52 + 52 + 8);
+        unsafe { out.set_len(52 + 52 + 8) };
+        unsafe { write_bytes_at(&mut out, 0, self.attestation_pubkey.as_ref()) };
+        unsafe { write_bytes_at(&mut out, 52, self.proposal_pubkey.as_ref()) };
+        unsafe { write_bytes_at(&mut out, 104, &self.index.0.0.to_le_bytes()) };
         out
     }
 }
 
 impl SszDecode for Validator {
     fn decode_ssz(bytes: &[u8]) -> Result<Self, String> {
-        let pubkey = Bytes52::from_slice(&bytes[0..52]);
-        let index = ValidatorIndex::decode_ssz(&bytes[52..60])?;
+        let attestation_pubkey = Bytes52::from_slice(&bytes[0..52]);
+        let proposal_pubkey = Bytes52::from_slice(&bytes[52..104]);
+        let index = ValidatorIndex::decode_ssz(&bytes[104..112])?;
         let balance = Uint64(0);
         Ok(Validator {
-            pubkey,
+            attestation_pubkey,
+            proposal_pubkey,
             index,
             balance,
         })
@@ -101,7 +104,7 @@ impl SszElement for Validator {
 
 impl Validator {
     pub fn decode_ssz_checked(bytes: &[u8]) -> Result<Self, String> {
-        const VALIDATOR_BYTES: usize = 60;
+        const VALIDATOR_BYTES: usize = 112;
         if bytes.len() != VALIDATOR_BYTES {
             return Err(format!(
                 "Validator expects {} bytes, got {}",
@@ -115,11 +118,13 @@ impl Validator {
 
 impl HashTreeRoot for Validator {
     fn hash_tree_root(&self) -> [u8; 32] {
-        let pubkey_root = Bytes32::from(self.pubkey.hash_tree_root());
+        let attestation_pubkey_root = Bytes32::from(self.attestation_pubkey.hash_tree_root());
+        let proposal_pubkey_root = Bytes32::from(self.proposal_pubkey.hash_tree_root());
         let index_root = Bytes32::from(self.index.hash_tree_root());
-        // Lean interop consensus root uses only (pubkey, index).
+        let pubkeys_root = hash_nodes(&attestation_pubkey_root, &proposal_pubkey_root);
+        // Lean interop consensus root uses only pubkeys + index.
         // `balance` is local metadata and is intentionally excluded.
-        let root = hash_nodes(&pubkey_root, &index_root);
+        let root = hash_nodes(&pubkeys_root, &index_root);
         *root.as_ref()
     }
 }

--- a/src/containers/validator.rs
+++ b/src/containers/validator.rs
@@ -1,5 +1,5 @@
 use crate::ssz::hash::hash_nodes;
-use crate::ssz::{HashTreeRoot, SszDecode, SszElement, SszEncode, SszFixedLen};
+use crate::ssz::{HashTreeRoot, SszDecode, SszEncode, SszFixedLen};
 use crate::types::bytes::Bytes32;
 use crate::types::bytes::Bytes52;
 use crate::types::container::Container;
@@ -95,10 +95,9 @@ impl SszDecode for Validator {
     }
 }
 
-impl SszElement for Validator {
-    #[inline]
-    fn fixed_len_opt() -> Option<usize> {
-        None
+impl SszFixedLen for Validator {
+    fn fixed_len() -> usize {
+        112
     }
 }
 

--- a/src/crypto/pq.rs
+++ b/src/crypto/pq.rs
@@ -37,6 +37,17 @@ pub enum DevnetValidatorKeyRole {
     Proposal,
 }
 
+#[inline]
+fn devnet_validator_seed(validator_index: usize, role: DevnetValidatorKeyRole) -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    let role_tag = match role {
+        DevnetValidatorKeyRole::Attestation => 0x4456_4E45_5431_0000u64,
+        DevnetValidatorKeyRole::Proposal => 0x4456_4E45_5431_5052u64,
+    };
+    seed[0..8].copy_from_slice(&(role_tag ^ (validator_index as u64)).to_le_bytes());
+    seed
+}
+
 /// Pre-computes aggregation proving artifacts.
 pub fn setup_aggregate_prover() {
     xmss_aggregation_setup_prover();
@@ -53,12 +64,7 @@ pub fn key_gen_for_devnet_validator_with_role(
     validator_index: usize,
     role: DevnetValidatorKeyRole,
 ) -> Result<(Bytes52, LeanSigSecretKey), String> {
-    let mut seed = [0u8; 32];
-    let role_tag = match role {
-        DevnetValidatorKeyRole::Attestation => 0x4456_4E45_5431_0000u64,
-        DevnetValidatorKeyRole::Proposal => 0x4456_4E45_5431_5052u64,
-    };
-    seed[0..8].copy_from_slice(&(role_tag ^ (validator_index as u64)).to_le_bytes());
+    let seed = devnet_validator_seed(validator_index, role);
     let mut rng = StdRng::from_seed(seed);
     let (pk, sk) =
         <LeanSigScheme as SignatureScheme>::key_gen(&mut rng, 0, DEVNET_KEY_ACTIVE_EPOCHS);
@@ -279,4 +285,21 @@ pub fn verify_aggregate_signature(
         .collect::<Result<Vec<_>, _>>()?;
     xmss_verify_aggregated_signatures(&pub_keys, message, &aggregate, epoch)
         .map_err(|err| format!("failed to verify aggregated signatures: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DevnetValidatorKeyRole, devnet_validator_seed};
+
+    #[test]
+    fn devnet_role_seeds_are_distinct_and_stable() {
+        let attestation = devnet_validator_seed(0, DevnetValidatorKeyRole::Attestation);
+        let proposal = devnet_validator_seed(0, DevnetValidatorKeyRole::Proposal);
+
+        assert_ne!(attestation, proposal);
+        assert_eq!(attestation[..8], [0, 0, 49, 84, 69, 78, 86, 68]);
+        assert_eq!(proposal[..8], [82, 80, 49, 84, 69, 78, 86, 68]);
+        assert!(attestation[8..].iter().all(|byte| *byte == 0));
+        assert!(proposal[8..].iter().all(|byte| *byte == 0));
+    }
 }

--- a/src/crypto/pq.rs
+++ b/src/crypto/pq.rs
@@ -47,17 +47,6 @@ pub fn setup_aggregate_verifier() {
     xmss_aggregation_setup_verifier();
 }
 
-/// Deterministically derives a validator keypair for a devnet validator index.
-///
-/// This is used for local-devnet key material so every client can derive the
-/// same validator registry without external key distribution.
-#[inline]
-pub fn key_gen_for_devnet_validator(
-    validator_index: usize,
-) -> Result<(Bytes52, LeanSigSecretKey), String> {
-    key_gen_for_devnet_validator_with_role(validator_index, DevnetValidatorKeyRole::Attestation)
-}
-
 /// Deterministically derives a role-specific validator keypair for local devnets.
 #[inline]
 pub fn key_gen_for_devnet_validator_with_role(

--- a/src/crypto/pq.rs
+++ b/src/crypto/pq.rs
@@ -31,6 +31,12 @@ pub type LeanSigSecretKey = <LeanSigScheme as SignatureScheme>::SecretKey;
 /// Narrow per-key active signing interval used for local devnet key material.
 const DEVNET_KEY_ACTIVE_EPOCHS: usize = 8;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DevnetValidatorKeyRole {
+    Attestation,
+    Proposal,
+}
+
 /// Pre-computes aggregation proving artifacts.
 pub fn setup_aggregate_prover() {
     xmss_aggregation_setup_prover();
@@ -49,9 +55,21 @@ pub fn setup_aggregate_verifier() {
 pub fn key_gen_for_devnet_validator(
     validator_index: usize,
 ) -> Result<(Bytes52, LeanSigSecretKey), String> {
+    key_gen_for_devnet_validator_with_role(validator_index, DevnetValidatorKeyRole::Attestation)
+}
+
+/// Deterministically derives a role-specific validator keypair for local devnets.
+#[inline]
+pub fn key_gen_for_devnet_validator_with_role(
+    validator_index: usize,
+    role: DevnetValidatorKeyRole,
+) -> Result<(Bytes52, LeanSigSecretKey), String> {
     let mut seed = [0u8; 32];
-    seed[0..8]
-        .copy_from_slice(&(0x4456_4E45_5431_0000u64 ^ (validator_index as u64)).to_le_bytes());
+    let role_tag = match role {
+        DevnetValidatorKeyRole::Attestation => 0x4456_4E45_5431_0000u64,
+        DevnetValidatorKeyRole::Proposal => 0x4456_4E45_5431_5052u64,
+    };
+    seed[0..8].copy_from_slice(&(role_tag ^ (validator_index as u64)).to_le_bytes());
     let mut rng = StdRng::from_seed(seed);
     let (pk, sk) =
         <LeanSigScheme as SignatureScheme>::key_gen(&mut rng, 0, DEVNET_KEY_ACTIVE_EPOCHS);

--- a/src/networking/mod.rs
+++ b/src/networking/mod.rs
@@ -44,7 +44,7 @@ pub use reqresp_handler::{NoopReqRespHandler, ReqRespHandler, StoreReqRespHandle
 pub use reqresp_messages::{LeanRequestMessage, LeanResponseMessage, LeanSupportedProtocol};
 pub use validate::{
     GossipSignatureVerifier, GossipValidatorKind, NoopGossipVerifier, SimpleGossipVerifier,
-    validate_gossip, verifier_from_validators,
+    validate_gossip, verifier_from_pubkeys, verifier_from_validators,
 };
 
 /// The fully-assembled networking runtime.

--- a/src/networking/mod.rs
+++ b/src/networking/mod.rs
@@ -44,7 +44,7 @@ pub use reqresp_handler::{NoopReqRespHandler, ReqRespHandler, StoreReqRespHandle
 pub use reqresp_messages::{LeanRequestMessage, LeanResponseMessage, LeanSupportedProtocol};
 pub use validate::{
     GossipSignatureVerifier, GossipValidatorKind, NoopGossipVerifier, SimpleGossipVerifier,
-    validate_gossip, verifier_from_pubkeys, verifier_from_validators,
+    validate_gossip, verifier_from_validators,
 };
 
 /// The fully-assembled networking runtime.

--- a/src/networking/validate.rs
+++ b/src/networking/validate.rs
@@ -23,6 +23,7 @@ use crate::crypto;
 use crate::ssz::HashTreeRoot;
 use crate::types::bitlist::BitList;
 use crate::types::bytes::{Bytes52, Bytes3112};
+use crate::unsafe_vec::write_at;
 use tracing::warn;
 
 /// Discriminant for selecting the gossip validator to run on a topic.
@@ -352,15 +353,26 @@ pub fn verifier_from_validators(validators: &[Validator]) -> Arc<dyn GossipSigna
     if validators.is_empty() {
         return Arc::new(NoopGossipVerifier);
     }
-    let pubkeys = validators
-        .iter()
-        .map(|validator| validator.attestation_pubkey)
-        .collect::<Vec<_>>();
-    let proposal_pubkeys = validators
-        .iter()
-        .map(|validator| validator.proposal_pubkey)
-        .collect::<Vec<_>>();
-    Arc::new(SimpleGossipVerifier::new(pubkeys, proposal_pubkeys))
+    let len = validators.len();
+    let mut attestation_pubkeys = Vec::with_capacity(len);
+    let mut proposal_pubkeys = Vec::with_capacity(len);
+    // SAFETY:
+    // - both vectors are allocated with capacity `len`.
+    // - the loop writes each slot in `0..len` exactly once.
+    // - lengths are increased only after the corresponding slots are initialized.
+    unsafe {
+        for (idx, validator) in validators.iter().enumerate() {
+            write_at(&mut attestation_pubkeys, idx, validator.attestation_pubkey);
+            write_at(&mut proposal_pubkeys, idx, validator.proposal_pubkey);
+            let initialized_len = idx.unchecked_add(1);
+            attestation_pubkeys.set_len(initialized_len);
+            proposal_pubkeys.set_len(initialized_len);
+        }
+    }
+    Arc::new(SimpleGossipVerifier::new(
+        attestation_pubkeys,
+        proposal_pubkeys,
+    ))
 }
 
 #[cfg(test)]

--- a/src/networking/validate.rs
+++ b/src/networking/validate.rs
@@ -450,65 +450,80 @@ mod tests {
 
     #[test]
     fn simple_verifier_uses_proposal_pubkeys_for_block_signatures() {
-        let (attestation_pubkey, attestation_signature) = {
-            pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
-                .map(|(pubkey, secret_key)| {
-                    let bits = BitList::new(vec![true]).expect("bits");
-                    let proposer_attestation = Attestation {
-                        aggregation_bits: bits,
-                        data: sample_attestation_data(4),
-                    };
-                    let message_root = proposer_attestation.data.hash_tree_root();
-                    let signature = pq::sign_message(&secret_key, 4, &message_root)
-                        .expect("attestation signature");
-                    (pubkey, signature)
-                })
-                .expect("attestation key")
-        };
-        let (proposal_pubkey, proposal_signature) = {
-            pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
-                .map(|(pubkey, secret_key)| {
-                    let bits = BitList::new(vec![true]).expect("bits");
-                    let proposer_attestation = Attestation {
-                        aggregation_bits: bits,
-                        data: sample_attestation_data(4),
-                    };
-                    let message_root = proposer_attestation.data.hash_tree_root();
-                    let signature =
-                        pq::sign_message(&secret_key, 4, &message_root).expect("proposal signature");
-                    (pubkey, signature)
-                })
-                .expect("proposal key")
-        };
+        std::thread::Builder::new()
+            .name("proposal-pubkey-verifier-test".to_string())
+            .stack_size(64 * 1024 * 1024)
+            .spawn(|| {
+                let (attestation_pubkey, attestation_signature) = {
+                    pq::key_gen_for_devnet_validator_with_role(
+                        0,
+                        DevnetValidatorKeyRole::Attestation,
+                    )
+                    .map(|(pubkey, secret_key)| {
+                        let bits = BitList::new(vec![true]).expect("bits");
+                        let proposer_attestation = Attestation {
+                            aggregation_bits: bits,
+                            data: sample_attestation_data(4),
+                        };
+                        let message_root = proposer_attestation.data.hash_tree_root();
+                        let signature = pq::sign_message(&secret_key, 4, &message_root)
+                            .expect("attestation signature");
+                        (pubkey, signature)
+                    })
+                    .expect("attestation key")
+                };
+                let (proposal_pubkey, proposal_signature) = {
+                    pq::key_gen_for_devnet_validator_with_role(
+                        0,
+                        DevnetValidatorKeyRole::Proposal,
+                    )
+                    .map(|(pubkey, secret_key)| {
+                        let bits = BitList::new(vec![true]).expect("bits");
+                        let proposer_attestation = Attestation {
+                            aggregation_bits: bits,
+                            data: sample_attestation_data(4),
+                        };
+                        let message_root = proposer_attestation.data.hash_tree_root();
+                        let signature = pq::sign_message(&secret_key, 4, &message_root)
+                            .expect("proposal signature");
+                        (pubkey, signature)
+                    })
+                    .expect("proposal key")
+                };
 
-        let verifier = SimpleGossipVerifier::new(vec![attestation_pubkey], vec![proposal_pubkey]);
-        let bits = BitList::new(vec![true]).expect("bits");
-        let proposer_attestation = Attestation {
-            aggregation_bits: bits,
-            data: sample_attestation_data(4),
-        };
-        let message = BlockWithAttestation {
-            block: Block {
-                slot: Slot(Uint64(4)),
-                proposer_index: ValidatorIndex(Uint64(0)),
-                parent_root: Bytes32::zero(),
-                state_root: Bytes32::zero(),
-                body: BlockBody {
-                    attestations: SszList::new(vec![]).expect("attestations"),
-                },
-            },
-            proposer_attestation: proposer_attestation.clone(),
-        };
+                let verifier =
+                    SimpleGossipVerifier::new(vec![attestation_pubkey], vec![proposal_pubkey]);
+                let bits = BitList::new(vec![true]).expect("bits");
+                let proposer_attestation = Attestation {
+                    aggregation_bits: bits,
+                    data: sample_attestation_data(4),
+                };
+                let message = BlockWithAttestation {
+                    block: Block {
+                        slot: Slot(Uint64(4)),
+                        proposer_index: ValidatorIndex(Uint64(0)),
+                        parent_root: Bytes32::zero(),
+                        state_root: Bytes32::zero(),
+                        body: BlockBody {
+                            attestations: SszList::new(vec![]).expect("attestations"),
+                        },
+                    },
+                    proposer_attestation: proposer_attestation.clone(),
+                };
 
-        assert!(verifier.verify_block_signature(
-            ValidatorIndex(Uint64(0)),
-            &message,
-            &proposal_signature
-        ));
-        assert!(!verifier.verify_block_signature(
-            ValidatorIndex(Uint64(0)),
-            &message,
-            &attestation_signature
-        ));
+                assert!(verifier.verify_block_signature(
+                    ValidatorIndex(Uint64(0)),
+                    &message,
+                    &proposal_signature
+                ));
+                assert!(!verifier.verify_block_signature(
+                    ValidatorIndex(Uint64(0)),
+                    &message,
+                    &attestation_signature
+                ));
+            })
+            .expect("spawn verifier test thread")
+            .join()
+            .expect("join verifier test thread");
     }
 }

--- a/src/networking/validate.rs
+++ b/src/networking/validate.rs
@@ -110,6 +110,11 @@ impl SimpleGossipVerifier {
     /// Keys must be ordered by validator index. Calls
     /// `setup_aggregate_verifier` to initialise any global verifier state.
     pub fn new(attestation_pubkeys: Vec<Bytes52>, proposal_pubkeys: Vec<Bytes52>) -> Self {
+        assert_eq!(
+            attestation_pubkeys.len(),
+            proposal_pubkeys.len(),
+            "attestation/proposal pubkey registries must have the same length"
+        );
         crypto::pq::setup_aggregate_verifier();
         Self {
             attestation_pubkeys,

--- a/src/networking/validate.rs
+++ b/src/networking/validate.rs
@@ -99,7 +99,8 @@ impl GossipSignatureVerifier for NoopGossipVerifier {
 /// Performs real PQ signature verification via `crypto::pq`. Initialises the
 /// aggregate verifier on construction via [`crypto::pq::setup_aggregate_verifier`].
 pub struct SimpleGossipVerifier {
-    pubkeys: Vec<Bytes52>,
+    attestation_pubkeys: Vec<Bytes52>,
+    proposal_pubkeys: Vec<Bytes52>,
 }
 
 impl SimpleGossipVerifier {
@@ -107,9 +108,12 @@ impl SimpleGossipVerifier {
     ///
     /// Keys must be ordered by validator index. Calls
     /// `setup_aggregate_verifier` to initialise any global verifier state.
-    pub fn new(pubkeys: Vec<Bytes52>) -> Self {
+    pub fn new(attestation_pubkeys: Vec<Bytes52>, proposal_pubkeys: Vec<Bytes52>) -> Self {
         crypto::pq::setup_aggregate_verifier();
-        Self { pubkeys }
+        Self {
+            attestation_pubkeys,
+            proposal_pubkeys,
+        }
     }
 }
 
@@ -123,7 +127,7 @@ impl GossipSignatureVerifier for SimpleGossipVerifier {
     ) -> bool {
         let proposer_attestation = &message.proposer_attestation;
         let idx = proposer_index.0.0 as usize;
-        let Some(pubkey) = self.pubkeys.get(idx) else {
+        let Some(pubkey) = self.proposal_pubkeys.get(idx) else {
             return false;
         };
         let root = proposer_attestation.data.hash_tree_root();
@@ -133,7 +137,7 @@ impl GossipSignatureVerifier for SimpleGossipVerifier {
 
     fn verify_signed_attestation_signature(&self, attestation: &SignedAttestation) -> bool {
         let idx = attestation.validator_id.0 as usize;
-        let Some(pubkey) = self.pubkeys.get(idx) else {
+        let Some(pubkey) = self.attestation_pubkeys.get(idx) else {
             return false;
         };
         let root = attestation.message.hash_tree_root();
@@ -146,7 +150,8 @@ impl GossipSignatureVerifier for SimpleGossipVerifier {
         attestation: &Attestation,
         proof: &AggregatedSignatureProof,
     ) -> bool {
-        let Some(participants) = gather_pubkeys(&self.pubkeys, &attestation.aggregation_bits)
+        let Some(participants) =
+            gather_pubkeys(&self.attestation_pubkeys, &attestation.aggregation_bits)
         else {
             return false;
         };
@@ -347,15 +352,32 @@ pub fn validate_gossip(
 ///
 /// Returns a [`NoopGossipVerifier`] if the registry is empty, otherwise a
 /// [`SimpleGossipVerifier`] built from the validators' public keys.
+pub fn verifier_from_pubkeys(
+    attestation_pubkeys: Vec<Bytes52>,
+    proposal_pubkeys: Vec<Bytes52>,
+) -> Arc<dyn GossipSignatureVerifier> {
+    if attestation_pubkeys.is_empty() {
+        return Arc::new(NoopGossipVerifier);
+    }
+    Arc::new(SimpleGossipVerifier::new(
+        attestation_pubkeys,
+        proposal_pubkeys,
+    ))
+}
+
 pub fn verifier_from_validators(validators: &[Validator]) -> Arc<dyn GossipSignatureVerifier> {
     if validators.is_empty() {
         return Arc::new(NoopGossipVerifier);
     }
     let pubkeys = validators
         .iter()
-        .map(|validator| validator.pubkey)
-        .collect();
-    Arc::new(SimpleGossipVerifier::new(pubkeys))
+        .map(|validator| validator.attestation_pubkey)
+        .collect::<Vec<_>>();
+    let proposal_pubkeys = validators
+        .iter()
+        .map(|validator| validator.proposal_pubkey)
+        .collect::<Vec<_>>();
+    Arc::new(SimpleGossipVerifier::new(pubkeys, proposal_pubkeys))
 }
 
 #[cfg(test)]
@@ -364,10 +386,15 @@ mod tests {
     use crate::containers::attestation::{
         AggregatedSignatureProof, Attestation, AttestationData, PROOF_MAX_BYTES,
     };
+    use crate::containers::block::{Block, BlockBody, BlockWithAttestation};
     use crate::containers::checkpoint::Checkpoint;
+    use crate::containers::validator::ValidatorIndex;
+    use crate::crypto::pq::{self, DevnetValidatorKeyRole};
+    use crate::ssz::HashTreeRoot;
     use crate::slot::Slot;
     use crate::types::bitlist::BitList;
     use crate::types::bytes::{ByteList, Bytes32, Bytes52};
+    use crate::types::collections::SszList;
     use crate::types::uint::Uint64;
 
     fn sample_attestation_data(slot: u64) -> AttestationData {
@@ -386,7 +413,8 @@ mod tests {
     #[test]
     fn simple_verifier_rejects_placeholder_aggregate_proof() {
         let verifier = SimpleGossipVerifier {
-            pubkeys: vec![Bytes52::from([0u8; 52])],
+            attestation_pubkeys: vec![Bytes52::from([0u8; 52])],
+            proposal_pubkeys: vec![Bytes52::from([0u8; 52])],
         };
         let bits = BitList::new(vec![true]).expect("bits");
         let attestation = Attestation {
@@ -404,7 +432,8 @@ mod tests {
     #[test]
     fn simple_verifier_rejects_invalid_non_placeholder_aggregate_proof() {
         let verifier = SimpleGossipVerifier {
-            pubkeys: vec![Bytes52::from([0u8; 52])],
+            attestation_pubkeys: vec![Bytes52::from([0u8; 52])],
+            proposal_pubkeys: vec![Bytes52::from([0u8; 52])],
         };
         let bits = BitList::new(vec![true]).expect("bits");
         let attestation = Attestation {
@@ -417,5 +446,50 @@ mod tests {
         };
 
         assert!(!verifier.verify_attestation_signature(&attestation, &proof));
+    }
+
+    #[test]
+    fn simple_verifier_uses_proposal_pubkeys_for_block_signatures() {
+        let (attestation_pubkey, attestation_secret_key) =
+            pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
+                .expect("attestation key");
+        let (proposal_pubkey, proposal_secret_key) =
+            pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
+                .expect("proposal key");
+
+        let verifier = SimpleGossipVerifier::new(vec![attestation_pubkey], vec![proposal_pubkey]);
+        let bits = BitList::new(vec![true]).expect("bits");
+        let proposer_attestation = Attestation {
+            aggregation_bits: bits,
+            data: sample_attestation_data(4),
+        };
+        let message = BlockWithAttestation {
+            block: Block {
+                slot: Slot(Uint64(4)),
+                proposer_index: ValidatorIndex(Uint64(0)),
+                parent_root: Bytes32::zero(),
+                state_root: Bytes32::zero(),
+                body: BlockBody {
+                    attestations: SszList::new(vec![]).expect("attestations"),
+                },
+            },
+            proposer_attestation: proposer_attestation.clone(),
+        };
+        let message_root = proposer_attestation.data.hash_tree_root();
+        let proposal_signature =
+            pq::sign_message(&proposal_secret_key, 4, &message_root).expect("proposal signature");
+        let attestation_signature = pq::sign_message(&attestation_secret_key, 4, &message_root)
+            .expect("attestation signature");
+
+        assert!(verifier.verify_block_signature(
+            ValidatorIndex(Uint64(0)),
+            &message,
+            &proposal_signature
+        ));
+        assert!(!verifier.verify_block_signature(
+            ValidatorIndex(Uint64(0)),
+            &message,
+            &attestation_signature
+        ));
     }
 }

--- a/src/networking/validate.rs
+++ b/src/networking/validate.rs
@@ -348,23 +348,6 @@ pub fn validate_gossip(
     }
 }
 
-/// Constructs the appropriate [`GossipSignatureVerifier`] for `validators`.
-///
-/// Returns a [`NoopGossipVerifier`] if the registry is empty, otherwise a
-/// [`SimpleGossipVerifier`] built from the validators' public keys.
-pub fn verifier_from_pubkeys(
-    attestation_pubkeys: Vec<Bytes52>,
-    proposal_pubkeys: Vec<Bytes52>,
-) -> Arc<dyn GossipSignatureVerifier> {
-    if attestation_pubkeys.is_empty() {
-        return Arc::new(NoopGossipVerifier);
-    }
-    Arc::new(SimpleGossipVerifier::new(
-        attestation_pubkeys,
-        proposal_pubkeys,
-    ))
-}
-
 pub fn verifier_from_validators(validators: &[Validator]) -> Arc<dyn GossipSignatureVerifier> {
     if validators.is_empty() {
         return Arc::new(NoopGossipVerifier);
@@ -450,12 +433,36 @@ mod tests {
 
     #[test]
     fn simple_verifier_uses_proposal_pubkeys_for_block_signatures() {
-        let (attestation_pubkey, attestation_secret_key) =
+        let (attestation_pubkey, attestation_signature) = {
             pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
-                .expect("attestation key");
-        let (proposal_pubkey, proposal_secret_key) =
+                .map(|(pubkey, secret_key)| {
+                    let bits = BitList::new(vec![true]).expect("bits");
+                    let proposer_attestation = Attestation {
+                        aggregation_bits: bits,
+                        data: sample_attestation_data(4),
+                    };
+                    let message_root = proposer_attestation.data.hash_tree_root();
+                    let signature = pq::sign_message(&secret_key, 4, &message_root)
+                        .expect("attestation signature");
+                    (pubkey, signature)
+                })
+                .expect("attestation key")
+        };
+        let (proposal_pubkey, proposal_signature) = {
             pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
-                .expect("proposal key");
+                .map(|(pubkey, secret_key)| {
+                    let bits = BitList::new(vec![true]).expect("bits");
+                    let proposer_attestation = Attestation {
+                        aggregation_bits: bits,
+                        data: sample_attestation_data(4),
+                    };
+                    let message_root = proposer_attestation.data.hash_tree_root();
+                    let signature =
+                        pq::sign_message(&secret_key, 4, &message_root).expect("proposal signature");
+                    (pubkey, signature)
+                })
+                .expect("proposal key")
+        };
 
         let verifier = SimpleGossipVerifier::new(vec![attestation_pubkey], vec![proposal_pubkey]);
         let bits = BitList::new(vec![true]).expect("bits");
@@ -475,11 +482,6 @@ mod tests {
             },
             proposer_attestation: proposer_attestation.clone(),
         };
-        let message_root = proposer_attestation.data.hash_tree_root();
-        let proposal_signature =
-            pq::sign_message(&proposal_secret_key, 4, &message_root).expect("proposal signature");
-        let attestation_signature = pq::sign_message(&attestation_secret_key, 4, &message_root)
-            .expect("attestation signature");
 
         assert!(verifier.verify_block_signature(
             ValidatorIndex(Uint64(0)),

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -373,11 +373,17 @@ ensure hash-sig-keys are available or use matching derivation for validator {}",
                 validator_key_source, settings.local_validator_index
             ));
         };
-        if local_key.attestation_pubkey != expected.attestation_pubkey {
+        if local_key.attestation_pubkey != expected.attestation_pubkey
+            || local_key.proposal_pubkey != expected.proposal_pubkey
+        {
             return Err(format!(
-                "local validator pubkey mismatch after filtering (source: {}); \
-expected {:?}, got {:?}",
-                validator_key_source, expected.attestation_pubkey, local_key.attestation_pubkey
+                "local validator key mismatch after filtering (source: {}); \
+expected attestation {:?} / proposal {:?}, got attestation {:?} / proposal {:?}",
+                validator_key_source,
+                expected.attestation_pubkey,
+                expected.proposal_pubkey,
+                local_key.attestation_pubkey,
+                local_key.proposal_pubkey
             ));
         }
         let (metrics_node_name, metrics_client_name) =

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -351,7 +351,7 @@ impl Node {
             filter_keys_against_genesis(&expected_genesis_state, devnet_validator_keys);
         if let Some(first) = expected_genesis_state.validators.first() {
             tracing::info!(
-                first_validator_pubkey = ?first.pubkey,
+                first_validator_pubkey = ?first.attestation_pubkey,
                 "peam startup: first validator pubkey"
             );
         }
@@ -373,11 +373,11 @@ ensure hash-sig-keys are available or use matching derivation for validator {}",
                 validator_key_source, settings.local_validator_index
             ));
         };
-        if local_key.pubkey != expected.pubkey {
+        if local_key.attestation_pubkey != expected.attestation_pubkey {
             return Err(format!(
                 "local validator pubkey mismatch after filtering (source: {}); \
 expected {:?}, got {:?}",
-                validator_key_source, expected.pubkey, local_key.pubkey
+                validator_key_source, expected.attestation_pubkey, local_key.attestation_pubkey
             ));
         }
         let (metrics_node_name, metrics_client_name) =

--- a/src/node/tasks.rs
+++ b/src/node/tasks.rs
@@ -100,13 +100,22 @@ pub(super) fn build_devnet_pq_validator_keys_from_hash_sig_dir(
 ) -> Result<DevnetValidatorKeyCache, String> {
     let mut keys = Vec::with_capacity(validator_count);
     for i in 0..validator_count {
-        let attestation_pk_path = hash_sig_keys_dir.join(format!("validator_{i}_attestation_pk.ssz"));
-        let attestation_sk_path = hash_sig_keys_dir.join(format!("validator_{i}_attestation_sk.ssz"));
+        let attestation_pk_path =
+            hash_sig_keys_dir.join(format!("validator_{i}_attestation_pk.ssz"));
+        let attestation_sk_path =
+            hash_sig_keys_dir.join(format!("validator_{i}_attestation_sk.ssz"));
         let proposal_pk_path = hash_sig_keys_dir.join(format!("validator_{i}_proposal_pk.ssz"));
         let proposal_sk_path = hash_sig_keys_dir.join(format!("validator_{i}_proposal_sk.ssz"));
 
         let attestation_pk_bytes = std::fs::read(&attestation_pk_path)
             .map_err(|err| format!("failed to read {}: {err}", attestation_pk_path.display()))?;
+        let attestation_sk_bytes = std::fs::read(&attestation_sk_path)
+            .map_err(|err| format!("failed to read {}: {err}", attestation_sk_path.display()))?;
+        let proposal_pk_bytes = std::fs::read(&proposal_pk_path)
+            .map_err(|err| format!("failed to read {}: {err}", proposal_pk_path.display()))?;
+        let proposal_sk_bytes = std::fs::read(&proposal_sk_path)
+            .map_err(|err| format!("failed to read {}: {err}", proposal_sk_path.display()))?;
+
         if attestation_pk_bytes.len() != 52 {
             return Err(format!(
                 "invalid public key length for {}: expected {}, got {}",
@@ -115,16 +124,6 @@ pub(super) fn build_devnet_pq_validator_keys_from_hash_sig_dir(
                 attestation_pk_bytes.len()
             ));
         }
-
-        let attestation_sk_bytes = std::fs::read(&attestation_sk_path)
-            .map_err(|err| format!("failed to read {}: {err}", attestation_sk_path.display()))?;
-        let attestation_secret_key =
-            crate::crypto::pq::LeanSigSecretKey::from_bytes(&attestation_sk_bytes).map_err(
-                |err| format!("failed to decode {}: {err:?}", attestation_sk_path.display()),
-            )?;
-
-        let proposal_pk_bytes = std::fs::read(&proposal_pk_path)
-            .map_err(|err| format!("failed to read {}: {err}", proposal_pk_path.display()))?;
         if proposal_pk_bytes.len() != 52 {
             return Err(format!(
                 "invalid public key length for {}: expected {}, got {}",
@@ -134,8 +133,10 @@ pub(super) fn build_devnet_pq_validator_keys_from_hash_sig_dir(
             ));
         }
 
-        let proposal_sk_bytes = std::fs::read(&proposal_sk_path)
-            .map_err(|err| format!("failed to read {}: {err}", proposal_sk_path.display()))?;
+        let attestation_secret_key =
+            crate::crypto::pq::LeanSigSecretKey::from_bytes(&attestation_sk_bytes).map_err(
+                |err| format!("failed to decode {}: {err:?}", attestation_sk_path.display()),
+            )?;
         let proposal_secret_key =
             crate::crypto::pq::LeanSigSecretKey::from_bytes(&proposal_sk_bytes).map_err(
                 |err| format!("failed to decode {}: {err:?}", proposal_sk_path.display()),
@@ -1221,8 +1222,8 @@ pub(super) fn spawn_block_production_task(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_devnet_pq_validator_keys, build_devnet_pq_validator_keys_from_hash_sig_dir,
-        PendingBlockAttestation, build_block_attestation_payload, load_attestation_data,
+        PendingBlockAttestation, build_block_attestation_payload,
+        build_devnet_pq_validator_keys_from_hash_sig_dir, load_attestation_data,
         load_proposal_pre_state,
     };
     use crate::containers::attestation::{
@@ -1233,7 +1234,6 @@ mod tests {
     };
     use crate::containers::checkpoint::Checkpoint;
     use crate::containers::state::{State, Validators};
-    use crate::crypto::pq::{self, DevnetValidatorKeyRole};
     use crate::containers::validator::ValidatorIndex;
     use crate::fork_choice::ForkChoiceStore;
     use crate::metrics::MetricsRegistry;
@@ -1243,7 +1243,6 @@ mod tests {
     use crate::types::bytes::{ByteList, Bytes32, Bytes3112};
     use crate::types::collections::SszList;
     use crate::types::uint::Uint64;
-    use leansig::serialization::Serializable;
     use peam_ssz::ssz::HashTreeRoot;
     use std::path::PathBuf;
     use std::sync::{Arc, RwLock};
@@ -1366,43 +1365,18 @@ mod tests {
     }
 
     #[test]
-    fn devnet_key_cache_splits_attestation_and_proposal_keys() {
-        let cache = build_devnet_pq_validator_keys(1);
-        let material = cache
-            .first()
-            .and_then(|entry| entry.as_ref())
-            .expect("validator key material");
-
-        assert_ne!(material.attestation_pubkey, material.proposal_pubkey);
-
-        let (expected_attestation_pubkey, _) =
-            pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
-                .expect("attestation key");
-        let (expected_proposal_pubkey, _) =
-            pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
-                .expect("proposal key");
-
-        assert_eq!(material.attestation_pubkey, expected_attestation_pubkey);
-        assert_eq!(material.proposal_pubkey, expected_proposal_pubkey);
-    }
-
-    #[test]
     fn strict_hash_sig_dir_requires_proposal_key_files() {
         let dir = temp_store_dir("strict_hash_sig_keys");
         std::fs::create_dir_all(&dir).expect("create dir");
 
-        let (attestation_pubkey, attestation_secret_key) =
-            pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
-                .expect("attestation key");
-
         std::fs::write(
             dir.join("validator_0_attestation_pk.ssz"),
-            attestation_pubkey.as_array(),
+            [7u8; 52],
         )
         .expect("write attestation pk");
         std::fs::write(
             dir.join("validator_0_attestation_sk.ssz"),
-            attestation_secret_key.to_bytes(),
+            [9u8; 32],
         )
         .expect("write attestation sk");
 

--- a/src/node/tasks.rs
+++ b/src/node/tasks.rs
@@ -46,8 +46,12 @@ pub struct PendingBlockAttestation {
 
 #[derive(Clone)]
 pub(super) struct DevnetValidatorKeyMaterial {
-    pub pubkey: Bytes52,
-    pub secret_key: Arc<crate::crypto::pq::LeanSigSecretKey>,
+    pub attestation_pubkey: Bytes52,
+    pub attestation_secret_key: Arc<crate::crypto::pq::LeanSigSecretKey>,
+    #[allow(dead_code)]
+    pub proposal_pubkey: Bytes52,
+    #[allow(dead_code)]
+    pub proposal_secret_key: Arc<crate::crypto::pq::LeanSigSecretKey>,
 }
 
 pub(super) type DevnetValidatorKeyCache = Arc<Vec<Option<DevnetValidatorKeyMaterial>>>;
@@ -56,13 +60,30 @@ pub(super) type DevnetValidatorKeyCache = Arc<Vec<Option<DevnetValidatorKeyMater
 pub(super) fn build_devnet_pq_validator_keys(validator_count: usize) -> DevnetValidatorKeyCache {
     let mut keys = Vec::with_capacity(validator_count);
     for i in 0..validator_count {
-        let material = match crate::crypto::pq::key_gen_for_devnet_validator(i) {
-            Ok((pubkey, secret_key)) => Some(DevnetValidatorKeyMaterial {
-                pubkey,
-                secret_key: Arc::new(secret_key),
-            }),
-            Err(err) => {
+        let material = match (
+            crate::crypto::pq::key_gen_for_devnet_validator_with_role(
+                i,
+                crate::crypto::pq::DevnetValidatorKeyRole::Attestation,
+            ),
+            crate::crypto::pq::key_gen_for_devnet_validator_with_role(
+                i,
+                crate::crypto::pq::DevnetValidatorKeyRole::Proposal,
+            ),
+        ) {
+            (Ok((attestation_pubkey, attestation_secret_key)), Ok((proposal_pubkey, proposal_secret_key))) => {
+                Some(DevnetValidatorKeyMaterial {
+                    attestation_pubkey,
+                    attestation_secret_key: Arc::new(attestation_secret_key),
+                    proposal_pubkey,
+                    proposal_secret_key: Arc::new(proposal_secret_key),
+                })
+            }
+            (Err(err), _) => {
                 warn!("failed to derive devnet validator key {i}: {err}");
+                None
+            }
+            (_, Err(err)) => {
+                warn!("failed to derive devnet proposal key {i}: {err}");
                 None
             }
         };
@@ -78,28 +99,82 @@ pub(super) fn build_devnet_pq_validator_keys_from_hash_sig_dir(
 ) -> Result<DevnetValidatorKeyCache, String> {
     let mut keys = Vec::with_capacity(validator_count);
     for i in 0..validator_count {
-        let pk_path = hash_sig_keys_dir.join(format!("validator_{i}_pk.ssz"));
-        let sk_path = hash_sig_keys_dir.join(format!("validator_{i}_sk.ssz"));
+        let attestation_pk_path = hash_sig_keys_dir.join(format!("validator_{i}_attestation_pk.ssz"));
+        let attestation_sk_path = hash_sig_keys_dir.join(format!("validator_{i}_attestation_sk.ssz"));
+        let legacy_pk_path = hash_sig_keys_dir.join(format!("validator_{i}_pk.ssz"));
+        let legacy_sk_path = hash_sig_keys_dir.join(format!("validator_{i}_sk.ssz"));
+        let proposal_pk_path = hash_sig_keys_dir.join(format!("validator_{i}_proposal_pk.ssz"));
+        let proposal_sk_path = hash_sig_keys_dir.join(format!("validator_{i}_proposal_sk.ssz"));
 
-        let pk_bytes = std::fs::read(&pk_path)
-            .map_err(|err| format!("failed to read {}: {err}", pk_path.display()))?;
-        if pk_bytes.len() != 52 {
+        let (attestation_pk_path, attestation_sk_path) = if attestation_pk_path.is_file()
+            && attestation_sk_path.is_file()
+        {
+            (attestation_pk_path, attestation_sk_path)
+        } else {
+            (legacy_pk_path, legacy_sk_path)
+        };
+
+        let attestation_pk_bytes = std::fs::read(&attestation_pk_path)
+            .map_err(|err| format!("failed to read {}: {err}", attestation_pk_path.display()))?;
+        if attestation_pk_bytes.len() != 52 {
             return Err(format!(
                 "invalid public key length for {}: expected {}, got {}",
-                pk_path.display(),
+                attestation_pk_path.display(),
                 52,
-                pk_bytes.len()
+                attestation_pk_bytes.len()
             ));
         }
 
-        let sk_bytes = std::fs::read(&sk_path)
-            .map_err(|err| format!("failed to read {}: {err}", sk_path.display()))?;
-        let secret_key = crate::crypto::pq::LeanSigSecretKey::from_bytes(&sk_bytes)
-            .map_err(|err| format!("failed to decode {}: {err:?}", sk_path.display()))?;
+        let attestation_sk_bytes = std::fs::read(&attestation_sk_path)
+            .map_err(|err| format!("failed to read {}: {err}", attestation_sk_path.display()))?;
+        let attestation_secret_key =
+            crate::crypto::pq::LeanSigSecretKey::from_bytes(&attestation_sk_bytes).map_err(
+                |err| format!("failed to decode {}: {err:?}", attestation_sk_path.display()),
+            )?;
+
+        let (proposal_pubkey, proposal_secret_key) = if proposal_pk_path.is_file()
+            && proposal_sk_path.is_file()
+        {
+            let proposal_pk_bytes = std::fs::read(&proposal_pk_path)
+                .map_err(|err| format!("failed to read {}: {err}", proposal_pk_path.display()))?;
+            if proposal_pk_bytes.len() != 52 {
+                return Err(format!(
+                    "invalid public key length for {}: expected {}, got {}",
+                    proposal_pk_path.display(),
+                    52,
+                    proposal_pk_bytes.len()
+                ));
+            }
+
+            let proposal_sk_bytes = std::fs::read(&proposal_sk_path)
+                .map_err(|err| format!("failed to read {}: {err}", proposal_sk_path.display()))?;
+            let proposal_secret_key =
+                crate::crypto::pq::LeanSigSecretKey::from_bytes(&proposal_sk_bytes).map_err(
+                    |err| format!("failed to decode {}: {err:?}", proposal_sk_path.display()),
+                )?;
+            (
+                Bytes52::from_slice(&proposal_pk_bytes),
+                Arc::new(proposal_secret_key),
+            )
+        } else {
+            warn!(
+                validator_index = i,
+                "proposal key files missing; deriving local devnet proposal key"
+            );
+            let (proposal_pubkey, proposal_secret_key) =
+                crate::crypto::pq::key_gen_for_devnet_validator_with_role(
+                    i,
+                    crate::crypto::pq::DevnetValidatorKeyRole::Proposal,
+                )
+                .map_err(|err| format!("failed to derive proposal key for validator {i}: {err}"))?;
+            (proposal_pubkey, Arc::new(proposal_secret_key))
+        };
 
         keys.push(Some(DevnetValidatorKeyMaterial {
-            pubkey: Bytes52::from_slice(&pk_bytes),
-            secret_key: Arc::new(secret_key),
+            attestation_pubkey: Bytes52::from_slice(&attestation_pk_bytes),
+            attestation_secret_key: Arc::new(attestation_secret_key),
+            proposal_pubkey,
+            proposal_secret_key,
         }));
     }
     Ok(Arc::new(keys))
@@ -205,7 +280,7 @@ pub(super) fn filter_keys_against_genesis(
         let matches = state
             .validators
             .get(i)
-            .map_or(false, |v| v.pubkey == key.pubkey);
+            .map_or(false, |v| v.attestation_pubkey == key.attestation_pubkey);
         if matches {
             filtered.push(Some(key.clone()));
             kept += 1;
@@ -245,8 +320,8 @@ pub(super) fn spawn_signed_attestation_task(
         warn!("failed to get local signing key from cache");
         return None;
     };
-    let local_pubkey = local_key.pubkey;
-    let local_secret_key = Arc::clone(&local_key.secret_key);
+    let local_pubkey = local_key.attestation_pubkey;
+    let local_secret_key = Arc::clone(&local_key.attestation_secret_key);
 
     {
         let guard = state.read().expect("state lock");
@@ -254,7 +329,7 @@ pub(super) fn spawn_signed_attestation_task(
             warn!("local validator index {local_validator_index} out of range; signing disabled");
             return None;
         };
-        if v.pubkey != local_pubkey {
+        if v.attestation_pubkey != local_pubkey {
             warn!("local validator pubkey mismatch; signing disabled");
             return None;
         }
@@ -349,6 +424,7 @@ pub(super) fn spawn_signed_attestation_task(
                 continue;
             }
             let sign_start = Instant::now();
+            // attestation signing
             let signature = match crate::crypto::pq::sign_message(
                 local_secret_key.as_ref(),
                 slot as u32,
@@ -544,7 +620,7 @@ fn aggregate_signed_attestations(
         let message_root = signed.message.hash_tree_root();
         let epoch = signed.message.slot.0.0 as u32;
         if crate::crypto::pq::verify_signature(
-            &key_material.pubkey,
+            &key_material.attestation_pubkey,
             epoch,
             &message_root,
             &signed.signature,
@@ -563,7 +639,7 @@ fn aggregate_signed_attestations(
         }
         entry
             .entries
-            .push((idx, key_material.pubkey, signed.signature));
+            .push((idx, key_material.attestation_pubkey, signed.signature));
     }
 
     let mut out = Vec::new();
@@ -699,14 +775,14 @@ fn build_block_attestation_payload(
                 signable = false;
                 break;
             };
-            let secret_key = key_material.secret_key.as_ref();
+            let secret_key = key_material.attestation_secret_key.as_ref();
             if !secret_key.get_activation_interval().contains(&slot)
                 || !secret_key.get_prepared_interval().contains(&slot)
             {
                 signable = false;
                 break;
             }
-            public_keys.push(key_material.pubkey);
+            public_keys.push(key_material.attestation_pubkey);
             secret_key_refs.push(secret_key);
         }
         if !signable || public_keys.is_empty() {
@@ -764,7 +840,7 @@ fn produce_block_with_signatures(
     pre_state: &State,
     slot: u64,
     local_validator_index: usize,
-    local_secret_key: &crate::crypto::pq::LeanSigSecretKey,
+    proposal_secret_key: &crate::crypto::pq::LeanSigSecretKey,
     fork_choice: Option<&ForkChoiceStore>,
     pending_block_attestations: &Arc<RwLock<Vec<PendingBlockAttestation>>>,
     devnet_validator_keys: &DevnetValidatorKeyCache,
@@ -853,11 +929,11 @@ fn produce_block_with_signatures(
 
     let proposer_message = proposer_attestation.data.hash_tree_root();
     let epoch = slot;
-    if !local_secret_key.get_activation_interval().contains(&epoch) {
+    if !proposal_secret_key.get_activation_interval().contains(&epoch) {
         warn!("skipping block proposal: key not active at epoch {}", epoch);
         return None;
     }
-    if !local_secret_key.get_prepared_interval().contains(&epoch) {
+    if !proposal_secret_key.get_prepared_interval().contains(&epoch) {
         warn!(
             "skipping block proposal: key not prepared at epoch {}",
             epoch
@@ -865,8 +941,10 @@ fn produce_block_with_signatures(
         return None;
     }
     let proposer_sign_start = Instant::now();
+    // Proposal signing
     let proposer_signature =
-        match crate::crypto::pq::sign_message(local_secret_key, slot as u32, &proposer_message) {
+        match crate::crypto::pq::sign_message(proposal_secret_key, slot as u32, &proposer_message)
+        {
             Ok(sig) => {
                 metrics
                     .pq_proposer_signing_time
@@ -962,8 +1040,8 @@ pub(super) fn spawn_block_production_task(
         warn!("failed to get local proposer key from cache");
         return None;
     };
-    let local_pubkey = local_key.pubkey;
-    let local_secret_key = Arc::clone(&local_key.secret_key);
+    let local_pubkey = local_key.attestation_pubkey;
+    let proposal_secret_key = Arc::clone(&local_key.proposal_secret_key);
 
     {
         let guard = state.read().expect("state lock");
@@ -973,7 +1051,7 @@ pub(super) fn spawn_block_production_task(
             );
             return None;
         };
-        if v.pubkey != local_pubkey {
+        if v.attestation_pubkey != local_pubkey {
             warn!("local validator pubkey mismatch; block production disabled");
             return None;
         }
@@ -1018,7 +1096,7 @@ pub(super) fn spawn_block_production_task(
                     &pre_state,
                     slot,
                     local_validator_index,
-                    local_secret_key.as_ref(),
+                    proposal_secret_key.as_ref(),
                     fork_choice_snapshot.as_ref(),
                     &pending_block_attestations,
                     &devnet_validator_keys,
@@ -1110,13 +1188,18 @@ pub(super) fn spawn_block_production_task(
 
 #[cfg(test)]
 mod tests {
-    use super::load_proposal_pre_state;
+    use super::{
+        build_devnet_pq_validator_keys, build_devnet_pq_validator_keys_from_hash_sig_dir,
+        load_proposal_pre_state,
+    };
     use crate::containers::checkpoint::Checkpoint;
     use crate::containers::state::{State, Validators};
+    use crate::crypto::pq::{self, DevnetValidatorKeyRole};
     use crate::slot::Slot;
     use crate::storage::{FileStore, Store};
     use crate::types::bytes::Bytes32;
     use crate::types::uint::Uint64;
+    use leansig::serialization::Serializable;
     use peam_ssz::ssz::HashTreeRoot;
     use std::path::PathBuf;
     use std::sync::{Arc, RwLock};
@@ -1140,6 +1223,63 @@ mod tests {
             State::generate_genesis(Uint64(0), Validators::new(vec![]).expect("validators"));
         state.slot = Slot(Uint64(slot));
         state
+    }
+
+    #[test]
+    fn devnet_key_cache_splits_attestation_and_proposal_keys() {
+        let cache = build_devnet_pq_validator_keys(1);
+        let material = cache
+            .first()
+            .and_then(|entry| entry.as_ref())
+            .expect("validator key material");
+
+        assert_ne!(material.attestation_pubkey, material.proposal_pubkey);
+
+        let (expected_attestation_pubkey, _) =
+            pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
+                .expect("attestation key");
+        let (expected_proposal_pubkey, _) =
+            pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
+                .expect("proposal key");
+
+        assert_eq!(material.attestation_pubkey, expected_attestation_pubkey);
+        assert_eq!(material.proposal_pubkey, expected_proposal_pubkey);
+    }
+
+    #[test]
+    fn legacy_hash_sig_files_fill_attestation_key_and_derive_proposal_key() {
+        let dir = temp_store_dir("legacy_hash_sig_keys");
+        std::fs::create_dir_all(&dir).expect("create dir");
+
+        let (attestation_pubkey, attestation_secret_key) =
+            pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
+                .expect("attestation key");
+        let (expected_proposal_pubkey, _) =
+            pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
+                .expect("proposal key");
+
+        std::fs::write(
+            dir.join("validator_0_pk.ssz"),
+            attestation_pubkey.as_array(),
+        )
+        .expect("write legacy pk");
+        std::fs::write(
+            dir.join("validator_0_sk.ssz"),
+            attestation_secret_key.to_bytes(),
+        )
+        .expect("write legacy sk");
+
+        let cache =
+            build_devnet_pq_validator_keys_from_hash_sig_dir(&dir, 1).expect("build key cache");
+        let material = cache
+            .first()
+            .and_then(|entry| entry.as_ref())
+            .expect("validator key material");
+
+        assert_eq!(material.attestation_pubkey, attestation_pubkey);
+        assert_eq!(material.proposal_pubkey, expected_proposal_pubkey);
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/src/node/tasks.rs
+++ b/src/node/tasks.rs
@@ -102,18 +102,8 @@ pub(super) fn build_devnet_pq_validator_keys_from_hash_sig_dir(
     for i in 0..validator_count {
         let attestation_pk_path = hash_sig_keys_dir.join(format!("validator_{i}_attestation_pk.ssz"));
         let attestation_sk_path = hash_sig_keys_dir.join(format!("validator_{i}_attestation_sk.ssz"));
-        let legacy_pk_path = hash_sig_keys_dir.join(format!("validator_{i}_pk.ssz"));
-        let legacy_sk_path = hash_sig_keys_dir.join(format!("validator_{i}_sk.ssz"));
         let proposal_pk_path = hash_sig_keys_dir.join(format!("validator_{i}_proposal_pk.ssz"));
         let proposal_sk_path = hash_sig_keys_dir.join(format!("validator_{i}_proposal_sk.ssz"));
-
-        let (attestation_pk_path, attestation_sk_path) = if attestation_pk_path.is_file()
-            && attestation_sk_path.is_file()
-        {
-            (attestation_pk_path, attestation_sk_path)
-        } else {
-            (legacy_pk_path, legacy_sk_path)
-        };
 
         let attestation_pk_bytes = std::fs::read(&attestation_pk_path)
             .map_err(|err| format!("failed to read {}: {err}", attestation_pk_path.display()))?;
@@ -133,49 +123,29 @@ pub(super) fn build_devnet_pq_validator_keys_from_hash_sig_dir(
                 |err| format!("failed to decode {}: {err:?}", attestation_sk_path.display()),
             )?;
 
-        let (proposal_pubkey, proposal_secret_key) = if proposal_pk_path.is_file()
-            && proposal_sk_path.is_file()
-        {
-            let proposal_pk_bytes = std::fs::read(&proposal_pk_path)
-                .map_err(|err| format!("failed to read {}: {err}", proposal_pk_path.display()))?;
-            if proposal_pk_bytes.len() != 52 {
-                return Err(format!(
-                    "invalid public key length for {}: expected {}, got {}",
-                    proposal_pk_path.display(),
-                    52,
-                    proposal_pk_bytes.len()
-                ));
-            }
+        let proposal_pk_bytes = std::fs::read(&proposal_pk_path)
+            .map_err(|err| format!("failed to read {}: {err}", proposal_pk_path.display()))?;
+        if proposal_pk_bytes.len() != 52 {
+            return Err(format!(
+                "invalid public key length for {}: expected {}, got {}",
+                proposal_pk_path.display(),
+                52,
+                proposal_pk_bytes.len()
+            ));
+        }
 
-            let proposal_sk_bytes = std::fs::read(&proposal_sk_path)
-                .map_err(|err| format!("failed to read {}: {err}", proposal_sk_path.display()))?;
-            let proposal_secret_key =
-                crate::crypto::pq::LeanSigSecretKey::from_bytes(&proposal_sk_bytes).map_err(
-                    |err| format!("failed to decode {}: {err:?}", proposal_sk_path.display()),
-                )?;
-            (
-                Bytes52::from_slice(&proposal_pk_bytes),
-                Arc::new(proposal_secret_key),
-            )
-        } else {
-            warn!(
-                validator_index = i,
-                "proposal key files missing; deriving local devnet proposal key"
-            );
-            let (proposal_pubkey, proposal_secret_key) =
-                crate::crypto::pq::key_gen_for_devnet_validator_with_role(
-                    i,
-                    crate::crypto::pq::DevnetValidatorKeyRole::Proposal,
-                )
-                .map_err(|err| format!("failed to derive proposal key for validator {i}: {err}"))?;
-            (proposal_pubkey, Arc::new(proposal_secret_key))
-        };
+        let proposal_sk_bytes = std::fs::read(&proposal_sk_path)
+            .map_err(|err| format!("failed to read {}: {err}", proposal_sk_path.display()))?;
+        let proposal_secret_key =
+            crate::crypto::pq::LeanSigSecretKey::from_bytes(&proposal_sk_bytes).map_err(
+                |err| format!("failed to decode {}: {err:?}", proposal_sk_path.display()),
+            )?;
 
         keys.push(Some(DevnetValidatorKeyMaterial {
             attestation_pubkey: Bytes52::from_slice(&attestation_pk_bytes),
             attestation_secret_key: Arc::new(attestation_secret_key),
-            proposal_pubkey,
-            proposal_secret_key,
+            proposal_pubkey: Bytes52::from_slice(&proposal_pk_bytes),
+            proposal_secret_key: Arc::new(proposal_secret_key),
         }));
     }
     Ok(Arc::new(keys))
@@ -281,14 +251,17 @@ pub(super) fn filter_keys_against_genesis(
         let matches = state
             .validators
             .get(i)
-            .map_or(false, |v| v.attestation_pubkey == key.attestation_pubkey);
+            .map_or(false, |v| {
+                v.attestation_pubkey == key.attestation_pubkey
+                    && v.proposal_pubkey == key.proposal_pubkey
+            });
         if matches {
             filtered.push(Some(key.clone()));
             kept += 1;
         } else {
             tracing::warn!(
                 validator_index = i,
-                "loaded key pubkey does not match genesis state; dropping"
+                "loaded validator keys do not match genesis state; dropping"
             );
             filtered.push(None);
             dropped += 1;
@@ -331,7 +304,7 @@ pub(super) fn spawn_signed_attestation_task(
             return None;
         };
         if v.attestation_pubkey != local_pubkey {
-            warn!("local validator pubkey mismatch; signing disabled");
+            warn!("local validator attestation key mismatch; signing disabled");
             return None;
         }
     }
@@ -1093,7 +1066,7 @@ pub(super) fn spawn_block_production_task(
             return None;
         };
         if v.attestation_pubkey != local_pubkey {
-            warn!("local validator pubkey mismatch; block production disabled");
+            warn!("local validator attestation key mismatch; block production disabled");
             return None;
         }
     }
@@ -1414,37 +1387,30 @@ mod tests {
     }
 
     #[test]
-    fn legacy_hash_sig_files_fill_attestation_key_and_derive_proposal_key() {
-        let dir = temp_store_dir("legacy_hash_sig_keys");
+    fn strict_hash_sig_dir_requires_proposal_key_files() {
+        let dir = temp_store_dir("strict_hash_sig_keys");
         std::fs::create_dir_all(&dir).expect("create dir");
 
         let (attestation_pubkey, attestation_secret_key) =
             pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
                 .expect("attestation key");
-        let (expected_proposal_pubkey, _) =
-            pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
-                .expect("proposal key");
 
         std::fs::write(
-            dir.join("validator_0_pk.ssz"),
+            dir.join("validator_0_attestation_pk.ssz"),
             attestation_pubkey.as_array(),
         )
-        .expect("write legacy pk");
+        .expect("write attestation pk");
         std::fs::write(
-            dir.join("validator_0_sk.ssz"),
+            dir.join("validator_0_attestation_sk.ssz"),
             attestation_secret_key.to_bytes(),
         )
-        .expect("write legacy sk");
+        .expect("write attestation sk");
 
-        let cache =
-            build_devnet_pq_validator_keys_from_hash_sig_dir(&dir, 1).expect("build key cache");
-        let material = cache
-            .first()
-            .and_then(|entry| entry.as_ref())
-            .expect("validator key material");
-
-        assert_eq!(material.attestation_pubkey, attestation_pubkey);
-        assert_eq!(material.proposal_pubkey, expected_proposal_pubkey);
+        let err = match build_devnet_pq_validator_keys_from_hash_sig_dir(&dir, 1) {
+            Ok(_) => panic!("missing proposal files must be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.contains("validator_0_proposal_pk.ssz"), "{err}");
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src/node/tasks.rs
+++ b/src/node/tasks.rs
@@ -49,9 +49,7 @@ pub struct PendingBlockAttestation {
 pub(super) struct DevnetValidatorKeyMaterial {
     pub attestation_pubkey: Bytes52,
     pub attestation_secret_key: Arc<crate::crypto::pq::LeanSigSecretKey>,
-    #[allow(dead_code)]
     pub proposal_pubkey: Bytes52,
-    #[allow(dead_code)]
     pub proposal_secret_key: Arc<crate::crypto::pq::LeanSigSecretKey>,
 }
 
@@ -654,10 +652,19 @@ fn aggregate_signed_attestations(
         let mut participants = Vec::with_capacity(group.entries.len());
         let mut public_keys = Vec::with_capacity(group.entries.len());
         let mut signatures = Vec::with_capacity(group.entries.len());
-        for (idx, pubkey, signature) in group.entries {
-            participants.push(idx);
-            public_keys.push(pubkey);
-            signatures.push(signature);
+        // SAFETY:
+        // - all three vectors are allocated with capacity `group.entries.len()`.
+        // - each slot is written exactly once before the corresponding length is increased.
+        unsafe {
+            for (slot, (idx, pubkey, signature)) in group.entries.into_iter().enumerate() {
+                crate::unsafe_vec::write_at(&mut participants, slot, idx);
+                crate::unsafe_vec::write_at(&mut public_keys, slot, pubkey);
+                crate::unsafe_vec::write_at(&mut signatures, slot, signature);
+                let initialized_len = slot.unchecked_add(1);
+                participants.set_len(initialized_len);
+                public_keys.set_len(initialized_len);
+                signatures.set_len(initialized_len);
+            }
         }
         let Some(max_idx) = participants.iter().copied().max() else {
             continue;

--- a/src/node/tasks.rs
+++ b/src/node/tasks.rs
@@ -1055,7 +1055,7 @@ pub(super) fn spawn_block_production_task(
         warn!("failed to get local proposer key from cache");
         return None;
     };
-    let local_pubkey = local_key.attestation_pubkey;
+    let local_proposal_pubkey = local_key.proposal_pubkey;
     let proposal_secret_key = Arc::clone(&local_key.proposal_secret_key);
 
     {
@@ -1066,8 +1066,8 @@ pub(super) fn spawn_block_production_task(
             );
             return None;
         };
-        if v.attestation_pubkey != local_pubkey {
-            warn!("local validator attestation key mismatch; block production disabled");
+        if v.proposal_pubkey != local_proposal_pubkey {
+            warn!("local validator proposal key mismatch; block production disabled");
             return None;
         }
     }

--- a/src/node/tasks.rs
+++ b/src/node/tasks.rs
@@ -14,7 +14,8 @@ use crate::containers::attestation::{
     VALIDATOR_REGISTRY_LIMIT,
 };
 use crate::containers::block::{
-    ATTESTATIONS_LIMIT, Block, BlockBody, BlockSignatures, BlockWithAttestation,
+    track_distinct_attestation_data, ATTESTATIONS_LIMIT, Block, BlockBody, BlockSignatures,
+    BlockWithAttestation, MAX_ATTESTATIONS_DATA,
     SignedBlockWithAttestation,
 };
 use crate::containers::checkpoint::Checkpoint;
@@ -746,10 +747,16 @@ fn build_block_attestation_payload(
     let mut proofs = Vec::new();
     let mut unaggregated = Vec::new();
     let mut stale_dropped = 0usize;
+    let mut attestation_data_limit_dropped = 0usize;
+    let mut included_data = Vec::with_capacity(MAX_ATTESTATIONS_DATA);
 
     for entry in drained {
         if entry.attestation.data.target.slot.0.0 < finalized_slot {
             stale_dropped += 1;
+            continue;
+        }
+        if !track_distinct_attestation_data(&mut included_data, &entry.attestation.data) {
+            attestation_data_limit_dropped += 1;
             continue;
         }
         if let Some(proof) = entry.proof {
@@ -772,7 +779,6 @@ fn build_block_attestation_payload(
             "proposal dropped stale pending attestations"
         );
     }
-
     if attestations.len() >= ATTESTATIONS_LIMIT {
         attestations.truncate(ATTESTATIONS_LIMIT);
         proofs.truncate(ATTESTATIONS_LIMIT);
@@ -783,6 +789,10 @@ fn build_block_attestation_payload(
     let aggregated = aggregate_attestations(unaggregated);
 
     for attestation in aggregated.into_iter().take(remaining) {
+        if !track_distinct_attestation_data(&mut included_data, &attestation.data) {
+            attestation_data_limit_dropped += 1;
+            continue;
+        }
         let participants = set_bits(&attestation.aggregation_bits);
         if participants.is_empty() {
             continue;
@@ -851,6 +861,15 @@ fn build_block_attestation_payload(
             proof_data,
         });
         attestations.push(attestation);
+    }
+    if attestation_data_limit_dropped > 0 {
+        warn!(
+            slot,
+            finalized_slot,
+            attestation_data_limit_dropped,
+            max_attestations_data = MAX_ATTESTATIONS_DATA,
+            "proposal dropped pending attestations beyond attestation-data limit"
+        );
     }
 
     (attestations, proofs)

--- a/src/storage/file_store.rs
+++ b/src/storage/file_store.rs
@@ -946,7 +946,8 @@ mod tests {
 
     fn single_validator_state() -> State {
         let validators = Validators::new(vec![Validator {
-            pubkey: Bytes52::from([0u8; 52]),
+            attestation_pubkey: Bytes52::from([0u8; 52]),
+            proposal_pubkey: Bytes52::from([1u8; 52]),
             index: ValidatorIndex(Uint64(0)),
             balance: Uint64(0),
         }])

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -61,6 +61,7 @@ impl Bytes3112 {
         Self([0u8; 3112])
     }
 
+    #[inline]
     pub fn from_slice(bytes: &[u8]) -> Self {
         let mut out = [0u8; 3112];
         out.copy_from_slice(&bytes[0..3112]);

--- a/tests/checkpoint_sync.rs
+++ b/tests/checkpoint_sync.rs
@@ -14,7 +14,8 @@ fn make_validators(n: usize) -> Validators {
     let mut vals = Vec::with_capacity(n);
     for i in 0..n {
         vals.push(Validator {
-            pubkey: Bytes52::from([i as u8; 52]),
+            attestation_pubkey: Bytes52::from([i as u8; 52]),
+            proposal_pubkey: Bytes52::from([(i as u8).saturating_add(1); 52]),
             index: ValidatorIndex(Uint64(i as u64)),
             balance: Uint64(0),
         });
@@ -72,7 +73,7 @@ fn verify_checkpoint_state_rejects_genesis_time_mismatch() {
 fn verify_checkpoint_state_rejects_validator_pubkey_mismatch() {
     let expected_genesis = base_state(10, 2);
     let mut state = expected_genesis.clone();
-    state.validators.as_mut_slice()[0].pubkey = Bytes52::from([9u8; 52]);
+    state.validators.as_mut_slice()[0].attestation_pubkey = Bytes52::from([9u8; 52]);
 
     let err = verify_checkpoint_state(&state, &expected_genesis).unwrap_err();
     assert!(err.contains("validator pubkey mismatch"), "{err}");

--- a/tests/config_parse.rs
+++ b/tests/config_parse.rs
@@ -293,7 +293,7 @@ fn parses_genesis_yaml_as_config_with_default_node_settings() {
     let config_path = dir.join("config.yaml");
     fs::write(
         &config_path,
-        "GENESIS_TIME: 42\nGENESIS_VALIDATORS:\n  - \"0xd1010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n",
+        "GENESIS_TIME: 42\nGENESIS_VALIDATORS:\n  - attestation_pubkey: \"0xd1010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n    proposal_pubkey: \"0xd2020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n",
     )
     .expect("write genesis yaml");
 
@@ -304,6 +304,28 @@ fn parses_genesis_yaml_as_config_with_default_node_settings() {
     assert_eq!(settings.http_address, "127.0.0.1");
     assert_eq!(settings.http_port, 8080);
     assert_eq!(settings.listen_addr, "/ip4/0.0.0.0/udp/9000/quic-v1");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn rejects_legacy_single_pubkey_genesis_yaml() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("peam_genesis_yaml_legacy_reject_{stamp}"));
+    fs::create_dir_all(&dir).expect("create temp dir");
+
+    let config_path = dir.join("config.yaml");
+    fs::write(
+        &config_path,
+        "GENESIS_TIME: 42\nGENESIS_VALIDATORS:\n  - \"0xd1010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n",
+    )
+    .expect("write legacy genesis yaml");
+
+    let err = peam::app::build_genesis_from_config_yaml(&config_path).expect_err("legacy genesis must be rejected");
+    assert!(err.contains("must be a mapping"), "{err}");
 
     let _ = fs::remove_dir_all(&dir);
 }

--- a/tests/config_parse.rs
+++ b/tests/config_parse.rs
@@ -309,6 +309,41 @@ fn parses_genesis_yaml_as_config_with_default_node_settings() {
 }
 
 #[test]
+fn parses_structured_devnet4_genesis_yaml() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("peam_genesis_yaml_devnet4_{stamp}"));
+    fs::create_dir_all(&dir).expect("create temp dir");
+
+    let config_path = dir.join("config.yaml");
+    fs::write(
+        &config_path,
+        "GENESIS_TIME: 42\nGENESIS_VALIDATORS:\n  - attestation_pubkey: \"0xd1010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n    proposal_pubkey: \"0xd2020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n",
+    )
+    .expect("write genesis yaml");
+
+    let (config, settings) = load_node_settings(&config_path).expect("parse genesis yaml");
+    assert_eq!(config.genesis_time.0, 42);
+    assert_eq!(settings.metrics_port, 8080);
+    assert!(settings.http_api);
+
+    let state = peam::app::build_genesis_from_config_yaml(&config_path).expect("build genesis");
+    let validator = state.validators.get(0).expect("validator");
+    assert_eq!(
+        validator.attestation_pubkey,
+        peam::types::bytes::Bytes52::from_slice(&[0xd1, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    );
+    assert_eq!(
+        validator.proposal_pubkey,
+        peam::types::bytes::Bytes52::from_slice(&[0xd2, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn resolves_local_validator_index_from_node_name() {
     let stamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/tests/fork_choice_store.rs
+++ b/tests/fork_choice_store.rs
@@ -112,7 +112,8 @@ fn build_signed_block(
 #[test]
 fn fork_choice_updates_head_on_new_block() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -132,7 +133,8 @@ fn fork_choice_updates_head_on_new_block() {
 #[test]
 fn fork_choice_uses_votes_to_pick_head() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -175,7 +177,8 @@ fn fork_choice_uses_votes_to_pick_head() {
 #[test]
 fn proposal_head_applies_pending_votes_before_returning_head() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -217,7 +220,8 @@ fn proposal_head_applies_pending_votes_before_returning_head() {
 #[test]
 fn node_proposal_helper_drains_pending_and_returns_head() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -262,17 +266,20 @@ fn node_proposal_helper_drains_pending_and_returns_head() {
 fn safe_target_advances_after_supermajority_votes() {
     let validators = Validators::new(vec![
         Validator {
-            pubkey: Bytes52::from([0x01u8; 52]),
+            attestation_pubkey: Bytes52::from([0x01u8; 52]),
+            proposal_pubkey: Bytes52::from([0x01u8; 52]),
             index: ValidatorIndex(Uint64(0)),
             balance: Uint64(0),
         },
         Validator {
-            pubkey: Bytes52::from([0x02u8; 52]),
+            attestation_pubkey: Bytes52::from([0x02u8; 52]),
+            proposal_pubkey: Bytes52::from([0x02u8; 52]),
             index: ValidatorIndex(Uint64(1)),
             balance: Uint64(0),
         },
         Validator {
-            pubkey: Bytes52::from([0x03u8; 52]),
+            attestation_pubkey: Bytes52::from([0x03u8; 52]),
+            proposal_pubkey: Bytes52::from([0x03u8; 52]),
             index: ValidatorIndex(Uint64(2)),
             balance: Uint64(0),
         },
@@ -311,7 +318,8 @@ fn safe_target_advances_after_supermajority_votes() {
 #[test]
 fn reorg_vote_shift_changes_head() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -380,7 +388,8 @@ fn reorg_vote_shift_changes_head() {
 #[test]
 fn head_slot_and_validator_count_getters() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -403,12 +412,14 @@ fn head_slot_and_validator_count_getters() {
 fn finalized_advance_prunes_old_fork_choice_history() {
     let validators = Validators::new(vec![
         Validator {
-            pubkey: Bytes52::from([0x01u8; 52]),
+            attestation_pubkey: Bytes52::from([0x01u8; 52]),
+            proposal_pubkey: Bytes52::from([0x01u8; 52]),
             index: ValidatorIndex(Uint64(0)),
             balance: Uint64(0),
         },
         Validator {
-            pubkey: Bytes52::from([0x02u8; 52]),
+            attestation_pubkey: Bytes52::from([0x02u8; 52]),
+            proposal_pubkey: Bytes52::from([0x02u8; 52]),
             index: ValidatorIndex(Uint64(1)),
             balance: Uint64(0),
         },

--- a/tests/lean_spec_container_placeholders.rs
+++ b/tests/lean_spec_container_placeholders.rs
@@ -147,17 +147,20 @@ fn lean_spec_attestation_aggregation() {
 fn lean_spec_state_aggregation() {
     let validators: Validators = SszList::new(vec![
         Validator {
-            pubkey: Bytes52::from([0x01u8; 52]),
+            attestation_pubkey: Bytes52::from([0x01u8; 52]),
+            proposal_pubkey: Bytes52::from([0x01u8; 52]),
             index: ValidatorIndex(Uint64(0)),
             balance: Uint64(0),
         },
         Validator {
-            pubkey: Bytes52::from([0x02u8; 52]),
+            attestation_pubkey: Bytes52::from([0x02u8; 52]),
+            proposal_pubkey: Bytes52::from([0x02u8; 52]),
             index: ValidatorIndex(Uint64(1)),
             balance: Uint64(0),
         },
         Validator {
-            pubkey: Bytes52::from([0x03u8; 52]),
+            attestation_pubkey: Bytes52::from([0x03u8; 52]),
+            proposal_pubkey: Bytes52::from([0x03u8; 52]),
             index: ValidatorIndex(Uint64(2)),
             balance: Uint64(0),
         },
@@ -246,17 +249,20 @@ fn lean_spec_state_aggregation() {
 fn lean_spec_state_justified_slots() {
     let validators: Validators = SszList::new(vec![
         Validator {
-            pubkey: Bytes52::from([0x01u8; 52]),
+            attestation_pubkey: Bytes52::from([0x01u8; 52]),
+            proposal_pubkey: Bytes52::from([0x01u8; 52]),
             index: ValidatorIndex(Uint64(0)),
             balance: Uint64(0),
         },
         Validator {
-            pubkey: Bytes52::from([0x02u8; 52]),
+            attestation_pubkey: Bytes52::from([0x02u8; 52]),
+            proposal_pubkey: Bytes52::from([0x02u8; 52]),
             index: ValidatorIndex(Uint64(1)),
             balance: Uint64(0),
         },
         Validator {
-            pubkey: Bytes52::from([0x03u8; 52]),
+            attestation_pubkey: Bytes52::from([0x03u8; 52]),
+            proposal_pubkey: Bytes52::from([0x03u8; 52]),
             index: ValidatorIndex(Uint64(2)),
             balance: Uint64(0),
         },
@@ -335,17 +341,20 @@ fn lean_spec_state_justified_slots() {
 fn lean_spec_state_process_attestations() {
     let validators: Validators = SszList::new(vec![
         Validator {
-            pubkey: Bytes52::from([0x01u8; 52]),
+            attestation_pubkey: Bytes52::from([0x01u8; 52]),
+            proposal_pubkey: Bytes52::from([0x01u8; 52]),
             index: ValidatorIndex(Uint64(0)),
             balance: Uint64(0),
         },
         Validator {
-            pubkey: Bytes52::from([0x02u8; 52]),
+            attestation_pubkey: Bytes52::from([0x02u8; 52]),
+            proposal_pubkey: Bytes52::from([0x02u8; 52]),
             index: ValidatorIndex(Uint64(1)),
             balance: Uint64(0),
         },
         Validator {
-            pubkey: Bytes52::from([0x03u8; 52]),
+            attestation_pubkey: Bytes52::from([0x03u8; 52]),
+            proposal_pubkey: Bytes52::from([0x03u8; 52]),
             index: ValidatorIndex(Uint64(2)),
             balance: Uint64(0),
         },

--- a/tests/lean_spec_genesis.rs
+++ b/tests/lean_spec_genesis.rs
@@ -15,7 +15,8 @@ fn make_validators(n: usize) -> Validators {
     unsafe { vals.set_len(n) };
     for i in 0..n {
         let v = Validator {
-            pubkey: Bytes52::from([0u8; 52]),
+            attestation_pubkey: Bytes52::from([0u8; 52]),
+            proposal_pubkey: Bytes52::from([0u8; 52]),
             index: ValidatorIndex(Uint64(i as u64)),
             balance: Uint64(0),
         };

--- a/tests/node_gossip_integration.rs
+++ b/tests/node_gossip_integration.rs
@@ -91,12 +91,15 @@ fn build_signed_block(state: &State, slot: u64) -> (SignedBlockWithAttestation, 
 #[test]
 #[ignore = "integration test uses placeholder signatures; pq path is covered separately"]
 fn gossip_block_updates_fork_choice_head() {
-    let (pubkey, _) =
+    let (attestation_pubkey, _) =
         key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
-            .expect("validator key");
+            .expect("attestation key");
+    let (proposal_pubkey, _) =
+        key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
+            .expect("proposal key");
     let v = Validator {
-        attestation_pubkey: pubkey,
-        proposal_pubkey: pubkey,
+        attestation_pubkey,
+        proposal_pubkey,
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -141,12 +144,15 @@ fn gossip_block_updates_fork_choice_head() {
 #[test]
 #[ignore = "integration test uses placeholder signatures; pq path is covered separately"]
 fn gossip_attestation_enqueues_for_aggregation_when_aggregator() {
-    let (pubkey, _) =
+    let (attestation_pubkey, _) =
         key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
-            .expect("validator key");
+            .expect("attestation key");
+    let (proposal_pubkey, _) =
+        key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
+            .expect("proposal key");
     let v = Validator {
-        attestation_pubkey: pubkey,
-        proposal_pubkey: pubkey,
+        attestation_pubkey,
+        proposal_pubkey,
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -234,12 +240,15 @@ fn gossip_attestation_enqueues_for_aggregation_when_aggregator() {
 
 #[test]
 fn gossip_block_enqueues_proposer_attestation_for_future_aggregation() {
-    let (pubkey, _) =
+    let (attestation_pubkey, _) =
         key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
-            .expect("validator key");
+            .expect("attestation key");
+    let (proposal_pubkey, _) =
+        key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
+            .expect("proposal key");
     let v = Validator {
-        attestation_pubkey: pubkey,
-        proposal_pubkey: pubkey,
+        attestation_pubkey,
+        proposal_pubkey,
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };

--- a/tests/node_gossip_integration.rs
+++ b/tests/node_gossip_integration.rs
@@ -8,7 +8,7 @@ use peam::containers::checkpoint::Checkpoint;
 use peam::containers::gossip::{GossipAttestation, GossipBlock};
 use peam::containers::state::{State, Validators};
 use peam::containers::validator::{Validator, ValidatorIndex};
-use peam::crypto::pq::{key_gen_for_devnet_validator, sign_message};
+use peam::crypto::pq::{DevnetValidatorKeyRole, key_gen_for_devnet_validator_with_role, sign_message};
 use peam::metrics::MetricsRegistry;
 use peam::networking::gossipsub::lean::topics::{LeanGossipTopic, LeanGossipTopicKind};
 use peam::node::handle_gossip_event;
@@ -61,7 +61,9 @@ fn build_signed_block(state: &State, slot: u64) -> (SignedBlockWithAttestation, 
             },
         },
     };
-    let (_, secret_key) = key_gen_for_devnet_validator(0).expect("validator key");
+    let (_, secret_key) =
+        key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
+            .expect("validator key");
     let proposer_message = proposer_attestation.data.hash_tree_root();
     let proposer_signature = sign_message(
         &secret_key,
@@ -89,9 +91,12 @@ fn build_signed_block(state: &State, slot: u64) -> (SignedBlockWithAttestation, 
 #[test]
 #[ignore = "integration test uses placeholder signatures; pq path is covered separately"]
 fn gossip_block_updates_fork_choice_head() {
-    let (pubkey, _) = key_gen_for_devnet_validator(0).expect("validator key");
+    let (pubkey, _) =
+        key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
+            .expect("validator key");
     let v = Validator {
-        pubkey,
+        attestation_pubkey: pubkey,
+        proposal_pubkey: pubkey,
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -136,9 +141,12 @@ fn gossip_block_updates_fork_choice_head() {
 #[test]
 #[ignore = "integration test uses placeholder signatures; pq path is covered separately"]
 fn gossip_attestation_enqueues_for_aggregation_when_aggregator() {
-    let (pubkey, _) = key_gen_for_devnet_validator(0).expect("validator key");
+    let (pubkey, _) =
+        key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
+            .expect("validator key");
     let v = Validator {
-        pubkey,
+        attestation_pubkey: pubkey,
+        proposal_pubkey: pubkey,
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -226,9 +234,12 @@ fn gossip_attestation_enqueues_for_aggregation_when_aggregator() {
 
 #[test]
 fn gossip_block_enqueues_proposer_attestation_for_future_aggregation() {
-    let (pubkey, _) = key_gen_for_devnet_validator(0).expect("validator key");
+    let (pubkey, _) =
+        key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
+            .expect("validator key");
     let v = Validator {
-        pubkey,
+        attestation_pubkey: pubkey,
+        proposal_pubkey: pubkey,
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };

--- a/tests/pq_devnet1_e2e.rs
+++ b/tests/pq_devnet1_e2e.rs
@@ -2,6 +2,7 @@ use peam::containers::attestation::{AttestationData, SignedAttestation};
 use peam::containers::checkpoint::Checkpoint;
 use peam::containers::gossip::GossipAttestation;
 use peam::containers::validator::{Validator, ValidatorIndex};
+use peam::crypto::pq::DevnetValidatorKeyRole;
 use peam::crypto::{PQ_ACTIVATION_TIME_EPOCHS, pq};
 use peam::networking::{GossipValidatorKind, validate_gossip, verifier_from_validators};
 use peam::slot::Slot;
@@ -12,9 +13,12 @@ use peam::types::uint::Uint64;
 #[test]
 #[ignore = "expensive pq key generation/signing; run explicitly for devnet-1 validation"]
 fn pq_signed_attestation_validates_through_gossip_pipeline() {
-    let (pubkey, secret_key) = pq::key_gen_for_devnet_validator(0).expect("keygen");
+    let (pubkey, secret_key) =
+        pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
+            .expect("keygen");
     let validators = vec![Validator {
-        pubkey,
+        attestation_pubkey: pubkey,
+        proposal_pubkey: pubkey,
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     }];
@@ -61,8 +65,12 @@ fn pq_multisig_aggregate_sign_and_verify_roundtrip() {
     pq::setup_aggregate_prover();
     pq::setup_aggregate_verifier();
 
-    let (pk0, sk0) = pq::key_gen_for_devnet_validator(0).expect("k0");
-    let (pk1, sk1) = pq::key_gen_for_devnet_validator(1).expect("k1");
+    let (pk0, sk0) =
+        pq::key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
+            .expect("k0");
+    let (pk1, sk1) =
+        pq::key_gen_for_devnet_validator_with_role(1, DevnetValidatorKeyRole::Attestation)
+            .expect("k1");
 
     let message = [0x5Au8; 32];
     let aggregate = pq::sign_aggregate(&[pk0, pk1], &[&sk0, &sk1], 1, &message).expect("aggregate");

--- a/tests/ream_networking_ports.rs
+++ b/tests/ream_networking_ports.rs
@@ -38,12 +38,15 @@ fn empty_state() -> Arc<RwLock<State>> {
 }
 
 fn single_validator_state() -> Arc<RwLock<State>> {
-    let (pubkey, _) =
+    let (attestation_pubkey, _) =
         key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
-            .expect("validator key");
+            .expect("attestation key");
+    let (proposal_pubkey, _) =
+        key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
+            .expect("proposal key");
     let validators = Validators::new(vec![Validator {
-        attestation_pubkey: pubkey,
-        proposal_pubkey: pubkey,
+        attestation_pubkey,
+        proposal_pubkey,
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     }])

--- a/tests/ream_networking_ports.rs
+++ b/tests/ream_networking_ports.rs
@@ -11,7 +11,7 @@ use peam::containers::checkpoint::Checkpoint;
 use peam::containers::req_resp::{BlocksByRootRequest, MAX_BLOCKS_PER_ROOT_REQUEST, Status};
 use peam::containers::state::{State, Validators};
 use peam::containers::validator::{Validator, ValidatorIndex};
-use peam::crypto::pq::{key_gen_for_devnet_validator, sign_message};
+use peam::crypto::pq::{DevnetValidatorKeyRole, key_gen_for_devnet_validator_with_role, sign_message};
 use peam::networking::gossipsub::context::StateGossipContext;
 use peam::networking::{
     LeanRequestMessage, LeanResponseMessage, LeanSupportedProtocol, NetworkEvent, NetworkEventBus,
@@ -38,9 +38,12 @@ fn empty_state() -> Arc<RwLock<State>> {
 }
 
 fn single_validator_state() -> Arc<RwLock<State>> {
-    let (pubkey, _) = key_gen_for_devnet_validator(0).expect("validator key");
+    let (pubkey, _) =
+        key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Attestation)
+            .expect("validator key");
     let validators = Validators::new(vec![Validator {
-        pubkey,
+        attestation_pubkey: pubkey,
+        proposal_pubkey: pubkey,
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     }])
@@ -96,7 +99,9 @@ fn signed_block_for_state(state: &State, slot: u64) -> SignedBlockWithAttestatio
         },
     };
 
-    let (_, secret_key) = key_gen_for_devnet_validator(0).expect("validator key");
+    let (_, secret_key) =
+        key_gen_for_devnet_validator_with_role(0, DevnetValidatorKeyRole::Proposal)
+            .expect("validator key");
     let proposer_message = proposer_attestation.data.hash_tree_root();
     let proposer_signature = sign_message(
         &secret_key,

--- a/tests/req_resp.rs
+++ b/tests/req_resp.rs
@@ -27,7 +27,8 @@ fn compute_state_root_for_block(state: &State, block: &Block) -> Bytes32 {
 
 fn dummy_signed_block() -> SignedBlockWithAttestation {
     let v = peam::containers::validator::Validator {
-        pubkey: peam::types::bytes::Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: peam::types::bytes::Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: peam::types::bytes::Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };

--- a/tests/ssz_containers.rs
+++ b/tests/ssz_containers.rs
@@ -50,25 +50,28 @@ fn checkpoint_hash_tree_root_matches_manual_chunks() {
 
 #[test]
 fn validator_encode_decode_roundtrip() {
-    let mut pubkey_bytes = [0u8; 52];
-    for (i, b) in pubkey_bytes.iter_mut().enumerate() {
+    let mut attestation_pubkey_bytes = [0u8; 52];
+    for (i, b) in attestation_pubkey_bytes.iter_mut().enumerate() {
         *b = i as u8;
     }
-    let pubkey = Bytes52::from(pubkey_bytes);
+    let attestation_pubkey = Bytes52::from(attestation_pubkey_bytes);
+    let proposal_pubkey = Bytes52::from([0xABu8; 52]);
     let index = ValidatorIndex(Uint64(5));
     let balance = Uint64(0);
     let validator = Validator {
-        pubkey,
+        attestation_pubkey,
+        proposal_pubkey,
         index,
         balance,
     };
 
     let encoded = validator.encode_ssz();
     let mut expected = Vec::new();
-    expected.extend_from_slice(pubkey.as_ref());
+    expected.extend_from_slice(attestation_pubkey.as_ref());
+    expected.extend_from_slice(proposal_pubkey.as_ref());
     expected.extend_from_slice(&5u64.to_le_bytes());
     assert_eq!(encoded, expected);
-    assert_eq!(encoded.len(), 60);
+    assert_eq!(encoded.len(), 112);
 
     let decoded = Validator::decode_ssz_checked(&encoded).expect("decode");
     assert_eq!(decoded, validator);
@@ -76,22 +79,31 @@ fn validator_encode_decode_roundtrip() {
 
 #[test]
 fn validator_hash_tree_root_matches_manual_chunks() {
-    let pubkey = Bytes52::from([0x22u8; 52]);
+    let attestation_pubkey = Bytes52::from([0x22u8; 52]);
+    let proposal_pubkey = Bytes52::from([0x33u8; 52]);
     let index = ValidatorIndex(Uint64(12));
     let balance = Uint64(0);
     let validator = Validator {
-        pubkey,
+        attestation_pubkey,
+        proposal_pubkey,
         index,
         balance,
     };
 
-    let pk = pubkey.as_array();
-    let chunk0 = Bytes32::from_slice(&pk[0..32]);
-    let chunk1 = chunk_from_bytes(&pk[32..52]);
-    let pubkey_root = hash_nodes(&chunk0, &chunk1);
+    let att = attestation_pubkey.as_array();
+    let att_chunk0 = Bytes32::from_slice(&att[0..32]);
+    let att_chunk1 = chunk_from_bytes(&att[32..52]);
+    let attestation_pubkey_root = hash_nodes(&att_chunk0, &att_chunk1);
+
+    let prop = proposal_pubkey.as_array();
+    let prop_chunk0 = Bytes32::from_slice(&prop[0..32]);
+    let prop_chunk1 = chunk_from_bytes(&prop[32..52]);
+    let proposal_pubkey_root = hash_nodes(&prop_chunk0, &prop_chunk1);
+
+    let pubkeys_root = hash_nodes(&attestation_pubkey_root, &proposal_pubkey_root);
 
     let index_chunk = chunk_from_bytes(&12u64.to_le_bytes());
-    let expected = hash_nodes(&pubkey_root, &index_chunk);
+    let expected = hash_nodes(&pubkeys_root, &index_chunk);
 
     assert_eq!(validator.hash_tree_root(), expected.as_array());
 }

--- a/tests/state_logic.rs
+++ b/tests/state_logic.rs
@@ -1265,9 +1265,12 @@ fn state_transition_processes_slots_then_block() {
 #[test]
 #[ignore = "expensive pq verifier path; run explicitly when exercising malformed aggregate proof handling"]
 fn pq_verifier_rejects_placeholder_aggregate_proof_for_block_attestation() {
-    let (pubkey, secret_key) = pq::key_gen_for_devnet_validator(0).expect("keygen");
+    let (pubkey, secret_key) =
+        pq::key_gen_for_devnet_validator_with_role(0, pq::DevnetValidatorKeyRole::Attestation)
+            .expect("keygen");
     let validator = Validator {
-        pubkey,
+        attestation_pubkey: pubkey,
+        proposal_pubkey: pubkey,
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };

--- a/tests/state_logic.rs
+++ b/tests/state_logic.rs
@@ -1,7 +1,7 @@
 use peam::containers::attestation::{AggregatedSignatureProof, Attestation, AttestationData};
 use peam::containers::block::{
     AttestationSignatures, Attestations, Block, BlockBody, BlockHeader, BlockSignatures,
-    BlockWithAttestation, SignedBlockWithAttestation,
+    BlockWithAttestation, SignedBlockWithAttestation, MAX_ATTESTATIONS_DATA,
 };
 use peam::containers::checkpoint::Checkpoint;
 use peam::containers::state::{
@@ -406,6 +406,73 @@ fn signed_block_proposer_attestation_slot_mismatch() {
 
     let err = state.process_signed_block(&signed).unwrap_err();
     assert!(err.contains("proposer attestation slot"));
+}
+
+#[test]
+fn signed_block_rejects_too_many_distinct_attestation_data_entries() {
+    let validators: Validators = SszList::new(vec![]).expect("validators");
+    let mut state = State::generate_genesis(Uint64(0), validators);
+
+    let attestations = (0..=MAX_ATTESTATIONS_DATA)
+        .map(|slot| Attestation {
+            aggregation_bits: BitList::new(vec![true]).expect("participants"),
+            data: AttestationData {
+                slot: Slot(Uint64(slot as u64)),
+                head: Checkpoint {
+                    root: Bytes32::from([slot as u8; 32]),
+                    slot: Slot(Uint64(slot as u64)),
+                },
+                target: Checkpoint {
+                    root: Bytes32::from([slot as u8; 32]),
+                    slot: Slot(Uint64(slot as u64)),
+                },
+                source: Checkpoint {
+                    root: Bytes32::from([slot.saturating_sub(1) as u8; 32]),
+                    slot: Slot(Uint64(slot.saturating_sub(1) as u64)),
+                },
+            },
+        })
+        .collect::<Vec<_>>();
+    let block = build_block_with_attestations_for_slot(&state, 1, 0, attestations.clone());
+    let proofs = attestations
+        .iter()
+        .map(|attestation| AggregatedSignatureProof {
+            participants: attestation.aggregation_bits.clone(),
+            proof_data: ByteList::new(vec![]).expect("proof"),
+        })
+        .collect::<Vec<_>>();
+    let signed = SignedBlockWithAttestation {
+        message: BlockWithAttestation {
+            block,
+            proposer_attestation: Attestation {
+                aggregation_bits: BitList::new(vec![true]).expect("participants"),
+                data: AttestationData {
+                    slot: Slot(Uint64(1)),
+                    head: Checkpoint {
+                        root: Bytes32::zero(),
+                        slot: Slot(Uint64(0)),
+                    },
+                    target: Checkpoint {
+                        root: Bytes32::zero(),
+                        slot: Slot(Uint64(0)),
+                    },
+                    source: Checkpoint {
+                        root: Bytes32::zero(),
+                        slot: Slot(Uint64(0)),
+                    },
+                },
+            },
+        },
+        signature: BlockSignatures {
+            attestation_signatures: SszList::new(proofs).expect("signatures"),
+            proposer_signature: Bytes3112::zero(),
+        },
+    };
+
+    let err = state
+        .process_signed_block_with_verifier(&signed, &NoopSignatureVerifier)
+        .expect_err("too many distinct attestation-data entries should be rejected");
+    assert!(err.contains("distinct attestation data entries"));
 }
 
 #[test]

--- a/tests/state_logic.rs
+++ b/tests/state_logic.rs
@@ -46,7 +46,8 @@ fn process_slots_caches_zeroed_latest_header_state_root() {
 #[test]
 fn process_block_header_updates_latest_header() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -74,7 +75,8 @@ fn process_block_header_updates_latest_header() {
 #[test]
 fn state_root_mismatch_error_does_not_mutate_state() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -202,7 +204,8 @@ fn apply_state_transition_for_test(state: &mut State, block: &Block) -> Result<(
 #[test]
 fn lean_spec_process_first_block_after_genesis() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -222,7 +225,8 @@ fn lean_spec_process_first_block_after_genesis() {
 #[test]
 fn lean_spec_linear_chain_multiple_blocks() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -240,7 +244,8 @@ fn lean_spec_linear_chain_multiple_blocks() {
 #[test]
 fn lean_spec_blocks_with_gaps() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -262,7 +267,8 @@ fn lean_spec_blocks_with_gaps() {
 #[test]
 fn lean_spec_block_at_large_slot_number() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -278,12 +284,14 @@ fn lean_spec_block_at_large_slot_number() {
 #[test]
 fn lean_spec_block_with_invalid_proposer() {
     let v0 = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
     let v1 = Validator {
-        pubkey: Bytes52::from([0x02u8; 52]),
+        attestation_pubkey: Bytes52::from([0x02u8; 52]),
+        proposal_pubkey: Bytes52::from([0x02u8; 52]),
         index: ValidatorIndex(Uint64(1)),
         balance: Uint64(0),
     };
@@ -300,7 +308,8 @@ fn lean_spec_block_with_invalid_proposer() {
 #[test]
 fn lean_spec_block_with_invalid_parent_root() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -402,12 +411,14 @@ fn signed_block_proposer_attestation_slot_mismatch() {
 #[test]
 fn signed_block_proposer_attestation_participant_mismatch() {
     let v0 = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
     let v1 = Validator {
-        pubkey: Bytes52::from([0x02u8; 52]),
+        attestation_pubkey: Bytes52::from([0x02u8; 52]),
+        proposal_pubkey: Bytes52::from([0x02u8; 52]),
         index: ValidatorIndex(Uint64(1)),
         balance: Uint64(0),
     };
@@ -452,12 +463,14 @@ fn signed_block_proposer_attestation_participant_mismatch() {
 #[test]
 fn signed_block_attestation_proof_participants_mismatch() {
     let v0 = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
     let v1 = Validator {
-        pubkey: Bytes52::from([0x02u8; 52]),
+        attestation_pubkey: Bytes52::from([0x02u8; 52]),
+        proposal_pubkey: Bytes52::from([0x02u8; 52]),
         index: ValidatorIndex(Uint64(1)),
         balance: Uint64(0),
     };
@@ -535,7 +548,8 @@ fn signed_block_signature_verifier_error() {
     }
 
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -582,7 +596,8 @@ fn signed_block_signature_verifier_error() {
 #[test]
 fn process_block_header_pushes_historical_hashes() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -612,7 +627,8 @@ fn process_block_header_pushes_historical_hashes() {
 #[test]
 fn first_post_genesis_block_seeds_checkpoint_roots_from_parent() {
     let v = Validator {
-        pubkey: Bytes52::from([0x02u8; 52]),
+        attestation_pubkey: Bytes52::from([0x02u8; 52]),
+        proposal_pubkey: Bytes52::from([0x02u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -642,17 +658,20 @@ fn first_post_genesis_block_seeds_checkpoint_roots_from_parent() {
 #[test]
 fn attestations_update_latest_justified() {
     let v0 = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
     let v1 = Validator {
-        pubkey: Bytes52::from([0x02u8; 52]),
+        attestation_pubkey: Bytes52::from([0x02u8; 52]),
+        proposal_pubkey: Bytes52::from([0x02u8; 52]),
         index: ValidatorIndex(Uint64(1)),
         balance: Uint64(0),
     };
     let v2 = Validator {
-        pubkey: Bytes52::from([0x03u8; 52]),
+        attestation_pubkey: Bytes52::from([0x03u8; 52]),
+        proposal_pubkey: Bytes52::from([0x03u8; 52]),
         index: ValidatorIndex(Uint64(2)),
         balance: Uint64(0),
     };
@@ -745,17 +764,20 @@ fn attestations_with_zero_validators_do_not_justify() {
 #[test]
 fn attestations_accumulate_votes_across_calls_for_justification_and_finalization() {
     let v0 = Validator {
-        pubkey: Bytes52::from([0x11u8; 52]),
+        attestation_pubkey: Bytes52::from([0x11u8; 52]),
+        proposal_pubkey: Bytes52::from([0x11u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
     let v1 = Validator {
-        pubkey: Bytes52::from([0x22u8; 52]),
+        attestation_pubkey: Bytes52::from([0x22u8; 52]),
+        proposal_pubkey: Bytes52::from([0x22u8; 52]),
         index: ValidatorIndex(Uint64(1)),
         balance: Uint64(0),
     };
     let v2 = Validator {
-        pubkey: Bytes52::from([0x33u8; 52]),
+        attestation_pubkey: Bytes52::from([0x33u8; 52]),
+        proposal_pubkey: Bytes52::from([0x33u8; 52]),
         index: ValidatorIndex(Uint64(2)),
         balance: Uint64(0),
     };
@@ -870,17 +892,20 @@ fn attestations_accumulate_votes_across_calls_for_justification_and_finalization
 #[test]
 fn attestations_with_mismatched_target_slot_root_are_ignored() {
     let v0 = Validator {
-        pubkey: Bytes52::from([0x11u8; 52]),
+        attestation_pubkey: Bytes52::from([0x11u8; 52]),
+        proposal_pubkey: Bytes52::from([0x11u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
     let v1 = Validator {
-        pubkey: Bytes52::from([0x22u8; 52]),
+        attestation_pubkey: Bytes52::from([0x22u8; 52]),
+        proposal_pubkey: Bytes52::from([0x22u8; 52]),
         index: ValidatorIndex(Uint64(1)),
         balance: Uint64(0),
     };
     let v2 = Validator {
-        pubkey: Bytes52::from([0x33u8; 52]),
+        attestation_pubkey: Bytes52::from([0x33u8; 52]),
+        proposal_pubkey: Bytes52::from([0x33u8; 52]),
         index: ValidatorIndex(Uint64(2)),
         balance: Uint64(0),
     };
@@ -935,17 +960,20 @@ fn attestations_with_mismatched_target_slot_root_are_ignored() {
 #[test]
 fn finalizes_when_target_is_next_valid_justifiable_slot_not_adjacent_slot() {
     let v0 = Validator {
-        pubkey: Bytes52::from([0x41u8; 52]),
+        attestation_pubkey: Bytes52::from([0x41u8; 52]),
+        proposal_pubkey: Bytes52::from([0x41u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
     let v1 = Validator {
-        pubkey: Bytes52::from([0x42u8; 52]),
+        attestation_pubkey: Bytes52::from([0x42u8; 52]),
+        proposal_pubkey: Bytes52::from([0x42u8; 52]),
         index: ValidatorIndex(Uint64(1)),
         balance: Uint64(0),
     };
     let v2 = Validator {
-        pubkey: Bytes52::from([0x43u8; 52]),
+        attestation_pubkey: Bytes52::from([0x43u8; 52]),
+        proposal_pubkey: Bytes52::from([0x43u8; 52]),
         index: ValidatorIndex(Uint64(2)),
         balance: Uint64(0),
     };
@@ -1007,17 +1035,20 @@ fn finalizes_when_target_is_next_valid_justifiable_slot_not_adjacent_slot() {
 #[test]
 fn duplicate_historical_roots_keep_pending_justifications_after_prune() {
     let v0 = Validator {
-        pubkey: Bytes52::from([0x51u8; 52]),
+        attestation_pubkey: Bytes52::from([0x51u8; 52]),
+        proposal_pubkey: Bytes52::from([0x51u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
     let v1 = Validator {
-        pubkey: Bytes52::from([0x52u8; 52]),
+        attestation_pubkey: Bytes52::from([0x52u8; 52]),
+        proposal_pubkey: Bytes52::from([0x52u8; 52]),
         index: ValidatorIndex(Uint64(1)),
         balance: Uint64(0),
     };
     let v2 = Validator {
-        pubkey: Bytes52::from([0x53u8; 52]),
+        attestation_pubkey: Bytes52::from([0x53u8; 52]),
+        proposal_pubkey: Bytes52::from([0x53u8; 52]),
         index: ValidatorIndex(Uint64(2)),
         balance: Uint64(0),
     };
@@ -1091,7 +1122,8 @@ fn duplicate_historical_roots_keep_pending_justifications_after_prune() {
 #[test]
 fn process_block_header_fills_empty_slots_with_zero_hashes() {
     let v = Validator {
-        pubkey: Bytes52::from([0x03u8; 52]),
+        attestation_pubkey: Bytes52::from([0x03u8; 52]),
+        proposal_pubkey: Bytes52::from([0x03u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -1123,7 +1155,8 @@ fn process_block_header_fills_empty_slots_with_zero_hashes() {
 #[test]
 fn historical_block_hashes_count_matches_expected() {
     let v = Validator {
-        pubkey: Bytes52::from([0x04u8; 52]),
+        attestation_pubkey: Bytes52::from([0x04u8; 52]),
+        proposal_pubkey: Bytes52::from([0x04u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -1151,7 +1184,8 @@ fn historical_block_hashes_count_matches_expected() {
 #[test]
 fn process_block_delegates_to_header() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };
@@ -1186,7 +1220,8 @@ fn process_block_delegates_to_header() {
 #[test]
 fn state_transition_processes_slots_then_block() {
     let v = Validator {
-        pubkey: Bytes52::from([0x01u8; 52]),
+        attestation_pubkey: Bytes52::from([0x01u8; 52]),
+        proposal_pubkey: Bytes52::from([0x01u8; 52]),
         index: ValidatorIndex(Uint64(0)),
         balance: Uint64(0),
     };

--- a/tests/state_ssz.rs
+++ b/tests/state_ssz.rs
@@ -9,7 +9,8 @@ use peam::types::uint::Uint64;
 #[test]
 fn state_encode_decode_roundtrip() {
     let v = Validator {
-        pubkey: Bytes52::from([0xAAu8; 52]),
+        attestation_pubkey: Bytes52::from([0xAAu8; 52]),
+        proposal_pubkey: Bytes52::from([0xAAu8; 52]),
         index: ValidatorIndex(Uint64(1)),
         balance: Uint64(0),
     };

--- a/tests/state_structs.rs
+++ b/tests/state_structs.rs
@@ -69,7 +69,8 @@ fn state_can_be_constructed_with_empty_lists() {
 #[test]
 fn validators_list_accepts_validators() {
     let v = Validator {
-        pubkey: Bytes52::from([0x11u8; 52]),
+        attestation_pubkey: Bytes52::from([0x11u8; 52]),
+        proposal_pubkey: Bytes52::from([0x11u8; 52]),
         index: ValidatorIndex(Uint64(7)),
         balance: Uint64(0),
     };


### PR DESCRIPTION
## Summary
- cap distinct block attestation-data entries at 16 for devnet4 alignment
- enforce the cap in block validation/state processing and in local block production
- add a regression test covering rejection of blocks with too many distinct attestation-data entries

## Verification
- cargo build -q
- cargo test -q signed_block_rejects_too_many_distinct_attestation_data_entries --test state_logic

## Follow-up
- true single-attestation-data compaction still needs recursive proof aggregation support in Peam's PQ layer