### PR TITLE
Cap block attestation data entries at 16

### DIFF
--- a/src/containers/attestation.rs
+++ b/src/containers/attestation.rs
@@ -43,7 +43,7 @@ pub const PROOF_MAX_BYTES: usize = 1_048_576;
 /// | 8 – 47     | `head`   |
 /// | 48 – 87    | `target` |
 /// | 88 – 127   | `source` |
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct AttestationData {
     /// Slot at which the attestation was created.
     pub slot: Slot,

--- a/src/containers/block.rs
+++ b/src/containers/block.rs
@@ -12,6 +12,8 @@ use crate::unsafe_vec::write_bytes_at;
 
 /// Maximum number of attestations that can appear in a single block body.
 pub const ATTESTATIONS_LIMIT: usize = 4_096;
+/// Maximum number of distinct attestation-data entries that can appear in a block body.
+pub const MAX_ATTESTATIONS_DATA: usize = 16;
 
 /// SSZ list of [`Attestation`]s included in a block body.
 pub type Attestations = SszList<Attestation, ATTESTATIONS_LIMIT>;
@@ -177,6 +179,7 @@ impl SignedBlockWithAttestation {
                 ));
             }
         }
+        validate_attestation_data_limit(&block.body.attestations)?;
         let proposer_attestation = &self.message.proposer_attestation;
         if proposer_attestation.data.slot != block.slot {
             return Err("proposer attestation slot does not match block slot".to_string());
@@ -188,6 +191,35 @@ impl SignedBlockWithAttestation {
         }
         Ok(())
     }
+}
+
+#[inline]
+pub fn validate_attestation_data_limit(attestations: &Attestations) -> Result<(), String> {
+    let mut distinct = Vec::with_capacity(MAX_ATTESTATIONS_DATA);
+    for attestation in attestations.iter() {
+        if !track_distinct_attestation_data(&mut distinct, &attestation.data) {
+            return Err(format!(
+                "block contains more than {} distinct attestation data entries",
+                MAX_ATTESTATIONS_DATA
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[inline]
+pub(crate) fn track_distinct_attestation_data(
+    distinct: &mut Vec<AttestationData>,
+    data: &AttestationData,
+) -> bool {
+    if distinct.iter().any(|existing| existing == data) {
+        return true;
+    }
+    if distinct.len() >= MAX_ATTESTATIONS_DATA {
+        return false;
+    }
+    distinct.push(data.clone());
+    true
 }
 
 /// Return the index of the single set bit in `bits`, or `None` if there are zero

--- a/src/containers/state.rs
+++ b/src/containers/state.rs
@@ -358,6 +358,7 @@ impl State {
         if expected_root != Bytes32::from(body_root) {
             return Err("block body root does not match header".to_string());
         }
+        crate::containers::block::validate_attestation_data_limit(&body.attestations)?;
         self.process_attestations(&body.attestations)?;
         Ok(())
     }

--- a/src/node/tasks.rs
+++ b/src/node/tasks.rs
@@ -14,7 +14,8 @@ use crate::containers::attestation::{
     VALIDATOR_REGISTRY_LIMIT,
 };
 use crate::containers::block::{
-    ATTESTATIONS_LIMIT, Block, BlockBody, BlockSignatures, BlockWithAttestation,
+    track_distinct_attestation_data, ATTESTATIONS_LIMIT, Block, BlockBody, BlockSignatures,
+    BlockWithAttestation, MAX_ATTESTATIONS_DATA,
     SignedBlockWithAttestation,
 };
 use crate::containers::checkpoint::Checkpoint;
@@ -689,10 +690,16 @@ fn build_block_attestation_payload(
     let mut proofs = Vec::new();
     let mut unaggregated = Vec::new();
     let mut stale_dropped = 0usize;
+    let mut attestation_data_limit_dropped = 0usize;
+    let mut included_data = Vec::with_capacity(MAX_ATTESTATIONS_DATA);
 
     for entry in drained {
         if entry.attestation.data.target.slot.0.0 < finalized_slot {
             stale_dropped += 1;
+            continue;
+        }
+        if !track_distinct_attestation_data(&mut included_data, &entry.attestation.data) {
+            attestation_data_limit_dropped += 1;
             continue;
         }
         if let Some(proof) = entry.proof {
@@ -715,7 +722,6 @@ fn build_block_attestation_payload(
             "proposal dropped stale pending attestations"
         );
     }
-
     if attestations.len() >= ATTESTATIONS_LIMIT {
         attestations.truncate(ATTESTATIONS_LIMIT);
         proofs.truncate(ATTESTATIONS_LIMIT);
@@ -726,6 +732,10 @@ fn build_block_attestation_payload(
     let aggregated = aggregate_attestations(unaggregated);
 
     for attestation in aggregated.into_iter().take(remaining) {
+        if !track_distinct_attestation_data(&mut included_data, &attestation.data) {
+            attestation_data_limit_dropped += 1;
+            continue;
+        }
         let participants = set_bits(&attestation.aggregation_bits);
         if participants.is_empty() {
             continue;
@@ -794,6 +804,15 @@ fn build_block_attestation_payload(
             proof_data,
         });
         attestations.push(attestation);
+    }
+    if attestation_data_limit_dropped > 0 {
+        warn!(
+            slot,
+            finalized_slot,
+            attestation_data_limit_dropped,
+            max_attestations_data = MAX_ATTESTATIONS_DATA,
+            "proposal dropped pending attestations beyond attestation-data limit"
+        );
     }
 
     (attestations, proofs)

--- a/tests/state_logic.rs
+++ b/tests/state_logic.rs
@@ -1,7 +1,7 @@
 use peam::containers::attestation::{AggregatedSignatureProof, Attestation, AttestationData};
 use peam::containers::block::{
     AttestationSignatures, Attestations, Block, BlockBody, BlockHeader, BlockSignatures,
-    BlockWithAttestation, SignedBlockWithAttestation,
+    BlockWithAttestation, SignedBlockWithAttestation, MAX_ATTESTATIONS_DATA,
 };
 use peam::containers::checkpoint::Checkpoint;
 use peam::containers::state::{
@@ -397,6 +397,73 @@ fn signed_block_proposer_attestation_slot_mismatch() {
 
     let err = state.process_signed_block(&signed).unwrap_err();
     assert!(err.contains("proposer attestation slot"));
+}
+
+#[test]
+fn signed_block_rejects_too_many_distinct_attestation_data_entries() {
+    let validators: Validators = SszList::new(vec![]).expect("validators");
+    let mut state = State::generate_genesis(Uint64(0), validators);
+
+    let attestations = (0..=MAX_ATTESTATIONS_DATA)
+        .map(|slot| Attestation {
+            aggregation_bits: BitList::new(vec![true]).expect("participants"),
+            data: AttestationData {
+                slot: Slot(Uint64(slot as u64)),
+                head: Checkpoint {
+                    root: Bytes32::from([slot as u8; 32]),
+                    slot: Slot(Uint64(slot as u64)),
+                },
+                target: Checkpoint {
+                    root: Bytes32::from([slot as u8; 32]),
+                    slot: Slot(Uint64(slot as u64)),
+                },
+                source: Checkpoint {
+                    root: Bytes32::from([slot.saturating_sub(1) as u8; 32]),
+                    slot: Slot(Uint64(slot.saturating_sub(1) as u64)),
+                },
+            },
+        })
+        .collect::<Vec<_>>();
+    let block = build_block_with_attestations_for_slot(&state, 1, 0, attestations.clone());
+    let proofs = attestations
+        .iter()
+        .map(|attestation| AggregatedSignatureProof {
+            participants: attestation.aggregation_bits.clone(),
+            proof_data: ByteList::new(vec![]).expect("proof"),
+        })
+        .collect::<Vec<_>>();
+    let signed = SignedBlockWithAttestation {
+        message: BlockWithAttestation {
+            block,
+            proposer_attestation: Attestation {
+                aggregation_bits: BitList::new(vec![true]).expect("participants"),
+                data: AttestationData {
+                    slot: Slot(Uint64(1)),
+                    head: Checkpoint {
+                        root: Bytes32::zero(),
+                        slot: Slot(Uint64(0)),
+                    },
+                    target: Checkpoint {
+                        root: Bytes32::zero(),
+                        slot: Slot(Uint64(0)),
+                    },
+                    source: Checkpoint {
+                        root: Bytes32::zero(),
+                        slot: Slot(Uint64(0)),
+                    },
+                },
+            },
+        },
+        signature: BlockSignatures {
+            attestation_signatures: SszList::new(proofs).expect("signatures"),
+            proposer_signature: Bytes3112::zero(),
+        },
+    };
+
+    let err = state
+        .process_signed_block_with_verifier(&signed, &NoopSignatureVerifier)
+        .expect_err("too many distinct attestation-data entries should be rejected");
+    assert!(err.contains("distinct attestation data entries"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- cap distinct block attestation-data entries at 16 for devnet4 alignment
- enforce the cap in block validation/state processing and in local block production
- add a regression test covering rejection of blocks with too many distinct attestation-data entries

## Verification
- cargo build -q
- cargo test -q signed_block_rejects_too_many_distinct_attestation_data_entries --test state_logic

## Follow-up
- true single-attestation-data compaction still needs recursive proof aggregation support in Peam's PQ layer